### PR TITLE
Add alpha channel to colors

### DIFF
--- a/examples/index.re
+++ b/examples/index.re
@@ -23,7 +23,7 @@ let make w (ymin, ymax) time => {
     color:
       Utils.lerpColor
         low::Constants.white
-        high::(Utils.color r::138 g::43 b::226)
+        high::(Utils.color r::138 g::43 b::226 ())
         value::(Utils.randomf min::0.3 max::1.),
     time
   }
@@ -37,15 +37,15 @@ type state = {
 
 let setup env => {
   Env.size width::640 height::360 env;
-  Draw.fill (Utils.color r::255 g::0 b::0) env;
+  Draw.fill (Utils.color r::255 g::0 b::0 ()) env;
   Draw.noStroke env;
   let lst = Array.init 500 (fun _ => make (Env.width env) ((-500), (-50)) 0);
   {lst, time: 0, running: true}
 };
 
 let draw {lst, running, time} env => {
-  Draw.background (Utils.color r::230 g::230 b::250) env;
-  Draw.fill (Utils.color r::255 g::0 b::0) env;
+  Draw.background (Utils.color r::230 g::230 b::250 ()) env;
+  Draw.fill (Utils.color r::255 g::0 b::0 ()) env;
   Utils.randomSeed time;
   let lst =
     Array.map

--- a/examples/index.re
+++ b/examples/index.re
@@ -23,7 +23,7 @@ let make w (ymin, ymax) time => {
     color:
       Utils.lerpColor
         low::Constants.white
-        high::(Utils.color r::138 g::43 b::226 ())
+        high::(Utils.color r::138 g::43 b::226 a::255)
         value::(Utils.randomf min::0.3 max::1.),
     time
   }
@@ -37,15 +37,15 @@ type state = {
 
 let setup env => {
   Env.size width::640 height::360 env;
-  Draw.fill (Utils.color r::255 g::0 b::0 ()) env;
+  Draw.fill (Utils.color r::255 g::0 b::0 a::255) env;
   Draw.noStroke env;
   let lst = Array.init 500 (fun _ => make (Env.width env) ((-500), (-50)) 0);
   {lst, time: 0, running: true}
 };
 
 let draw {lst, running, time} env => {
-  Draw.background (Utils.color r::230 g::230 b::250 ()) env;
-  Draw.fill (Utils.color r::255 g::0 b::0 ()) env;
+  Draw.background (Utils.color r::230 g::230 b::250 a::255) env;
+  Draw.fill (Utils.color r::255 g::0 b::0 a::255) env;
   Utils.randomSeed time;
   let lst =
     Array.map

--- a/examples/noise.re
+++ b/examples/noise.re
@@ -13,7 +13,7 @@ let setup env => {
 };
 
 let draw z env => {
-  background (color r::230 g::230 b::250 ()) env;
+  background (color r::230 g::230 b::250 a::255) env;
   let res = 100;
   let w = float_of_int (width env) /. float_of_int res;
   let h = float_of_int (height env) /. float_of_int res;

--- a/examples/noise.re
+++ b/examples/noise.re
@@ -13,7 +13,7 @@ let setup env => {
 };
 
 let draw z env => {
-  background (color r::230 g::230 b::250) env;
+  background (color r::230 g::230 b::250 ()) env;
   let res = 100;
   let w = float_of_int (width env) /. float_of_int res;
   let h = float_of_int (height env) /. float_of_int res;

--- a/examples/redsquare.re
+++ b/examples/redsquare.re
@@ -1,5 +1,7 @@
 open Reprocessing.Draw;
+
 open Reprocessing.Env;
+
 open Reprocessing.Utils;
 
 type state = (int, int);
@@ -13,7 +15,7 @@ let setup env => {
 };
 
 let draw squarePos env => {
-  background (color r::150 g::255 b::255 ()) env;
+  background (color r::150 g::255 b::255 a::255) env;
   let (sx, sy) = squarePos;
   let (px, py) = pmouse env;
   let (x, y) as squarePos =

--- a/examples/redsquare.re
+++ b/examples/redsquare.re
@@ -13,7 +13,7 @@ let setup env => {
 };
 
 let draw squarePos env => {
-  background (color r::150 g::255 b::255) env;
+  background (color r::150 g::255 b::255 ()) env;
   let (sx, sy) = squarePos;
   let (px, py) = pmouse env;
   let (x, y) as squarePos =

--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -12,9 +12,9 @@ type glState = Gl.Window.t;
 type glCamera = {projectionMatrix: Gl.Mat4.t};
 
 type colorT = {
-  r: int,
-  g: int,
-  b: int,
+  r: float,
+  g: float,
+  b: float,
   a: float
 };
 

--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -14,7 +14,8 @@ type glCamera = {projectionMatrix: Gl.Mat4.t};
 type colorT = {
   r: int,
   g: int,
-  b: int
+  b: int,
+  a: float
 };
 
 type styleT = {

--- a/src/Reprocessing_Constants.re
+++ b/src/Reprocessing_Constants.re
@@ -1,14 +1,14 @@
 open Reprocessing_Common;
 
-let white = {r: 255, g: 255, b: 255};
+let white = {r: 255, g: 255, b: 255, a: 1.};
 
-let black = {r: 0, g: 0, b: 0};
+let black = {r: 0, g: 0, b: 0, a: 1.};
 
-let red = {r: 255, g: 0, b: 0};
+let red = {r: 255, g: 0, b: 0, a: 1.};
 
-let green = {r: 0, g: 255, b: 0};
+let green = {r: 0, g: 255, b: 0, a: 1.};
 
-let blue = {r: 0, g: 0, b: 255};
+let blue = {r: 0, g: 0, b: 255, a: 1.};
 
 let pi = 4.0 *. atan 1.0;
 

--- a/src/Reprocessing_Constants.re
+++ b/src/Reprocessing_Constants.re
@@ -1,14 +1,14 @@
 open Reprocessing_Common;
 
-let white = {r: 255, g: 255, b: 255, a: 1.};
+let white = {r: 1., g: 1., b: 1., a: 1.};
 
-let black = {r: 0, g: 0, b: 0, a: 1.};
+let black = {r: 0., g: 0., b: 0., a: 1.};
 
-let red = {r: 255, g: 0, b: 0, a: 1.};
+let red = {r: 1., g: 0., b: 0., a: 1.};
 
-let green = {r: 0, g: 255, b: 0, a: 1.};
+let green = {r: 0., g: 1., b: 0., a: 1.};
 
-let blue = {r: 0, g: 0, b: 255, a: 1.};
+let blue = {r: 0., g: 0., b: 1., a: 1.};
 
 let pi = 4.0 *. atan 1.0;
 

--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -14,7 +14,8 @@ let getProgram
   Gl.compileShader ::context vertexShader;
   let compiledCorrectly =
     Gl.getShaderParameter
-      ::context shader::vertexShader paramName::Gl.Compile_status == 1;
+      ::context shader::vertexShader paramName::Gl.Compile_status
+    == 1;
   if compiledCorrectly {
     let fragmentShader =
       Gl.createShader ::context RGLConstants.fragment_shader;
@@ -23,7 +24,8 @@ let getProgram
     Gl.compileShader ::context fragmentShader;
     let compiledCorrectly =
       Gl.getShaderParameter
-        ::context shader::fragmentShader paramName::Gl.Compile_status == 1;
+        ::context shader::fragmentShader paramName::Gl.Compile_status
+      == 1;
     if compiledCorrectly {
       let program = Gl.createProgram ::context;
       Gl.attachShader ::context ::program shader::vertexShader;
@@ -32,22 +34,26 @@ let getProgram
       Gl.deleteShader ::context fragmentShader;
       Gl.linkProgram ::context program;
       let linkedCorrectly =
-        Gl.getProgramParameter ::context ::program paramName::Gl.Link_status == 1;
+        Gl.getProgramParameter ::context ::program paramName::Gl.Link_status
+        == 1;
       if linkedCorrectly {
         Some program
       } else {
-        print_endline @@
-        "Linking error: " ^ Gl.getProgramInfoLog ::context program;
+        print_endline
+        @@ "Linking error: "
+        ^ Gl.getProgramInfoLog ::context program;
         None
       }
     } else {
-      print_endline @@
-      "Fragment shader error: " ^ Gl.getShaderInfoLog ::context fragmentShader;
+      print_endline
+      @@ "Fragment shader error: "
+      ^ Gl.getShaderInfoLog ::context fragmentShader;
       None
     }
   } else {
-    print_endline @@
-    "Vertex shader error: " ^ Gl.getShaderInfoLog ::context vertexShader;
+    print_endline
+    @@ "Vertex shader error: "
+    ^ Gl.getShaderInfoLog ::context vertexShader;
     None
   }
 };
@@ -169,7 +175,7 @@ let createCanvas window (height: int) (width: int) :glEnv => {
     keyboard: {keyCode: Reprocessing_Events.Nothing},
     mouse: {pos: (0, 0), prevPos: (0, 0), pressed: false},
     style: {
-      fillColor: Some {r: 0, g: 0, b: 0},
+      fillColor: Some {r: 0, g: 0, b: 0, a: 1.},
       strokeWeight: 3,
       strokeCap: Round,
       strokeColor: None
@@ -294,9 +300,16 @@ let flushGlobalBatch env =>
 
 let maybeFlushBatch ::texture ::el ::vert env =>
   if (
-    env.batch.elementPtr + el >= circularBufferSize ||
-    env.batch.vertexPtr + vert >= circularBufferSize ||
-    env.batch.elementPtr > 0 && env.batch.currTex !== texture
+    env.batch.elementPtr
+    + el
+    >= circularBufferSize
+    || env.batch.vertexPtr
+    + vert
+    >= circularBufferSize
+    || env.batch.elementPtr
+    > 0
+    && env.batch.currTex
+    !== texture
   ) {
     flushGlobalBatch env
   };
@@ -332,7 +345,7 @@ let addRectToGlobalBatch
     bottomLeft::(x2, y2)
     topRight::(x3, y3)
     topLeft::(x4, y4)
-    color::{r, g, b} => {
+    color::{r, g, b, a} => {
   maybeFlushBatch texture::None el::6 vert::32 env;
   let set = Gl.Bigarray.set;
   let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
@@ -343,7 +356,7 @@ let addRectToGlobalBatch
   set vertexArrayToMutate (i + 2) r;
   set vertexArrayToMutate (i + 3) g;
   set vertexArrayToMutate (i + 4) b;
-  set vertexArrayToMutate (i + 5) 1.;
+  set vertexArrayToMutate (i + 5) a;
   set vertexArrayToMutate (i + 6) 0.0;
   set vertexArrayToMutate (i + 7) 0.0;
   set vertexArrayToMutate (i + 8) x2;
@@ -351,7 +364,7 @@ let addRectToGlobalBatch
   set vertexArrayToMutate (i + 10) r;
   set vertexArrayToMutate (i + 11) g;
   set vertexArrayToMutate (i + 12) b;
-  set vertexArrayToMutate (i + 13) 1.;
+  set vertexArrayToMutate (i + 13) a;
   set vertexArrayToMutate (i + 14) 0.0;
   set vertexArrayToMutate (i + 15) 0.0;
   set vertexArrayToMutate (i + 16) x3;
@@ -359,7 +372,7 @@ let addRectToGlobalBatch
   set vertexArrayToMutate (i + 18) r;
   set vertexArrayToMutate (i + 19) g;
   set vertexArrayToMutate (i + 20) b;
-  set vertexArrayToMutate (i + 21) 1.;
+  set vertexArrayToMutate (i + 21) a;
   set vertexArrayToMutate (i + 22) 0.0;
   set vertexArrayToMutate (i + 23) 0.0;
   set vertexArrayToMutate (i + 24) x4;
@@ -367,7 +380,7 @@ let addRectToGlobalBatch
   set vertexArrayToMutate (i + 26) r;
   set vertexArrayToMutate (i + 27) g;
   set vertexArrayToMutate (i + 28) b;
-  set vertexArrayToMutate (i + 29) 1.;
+  set vertexArrayToMutate (i + 29) a;
   set vertexArrayToMutate (i + 30) 0.0;
   set vertexArrayToMutate (i + 31) 0.0;
   let ii = i / vertexSize;
@@ -383,7 +396,7 @@ let addRectToGlobalBatch
   env.batch.elementPtr = j + 6
 };
 
-let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b} => {
+let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b, a} => {
   maybeFlushBatch texture::None vert::3 el::24 env;
   let set = Gl.Bigarray.set;
   let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
@@ -394,7 +407,7 @@ let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b} => {
   set vertexArrayToMutate (i + 2) r;
   set vertexArrayToMutate (i + 3) g;
   set vertexArrayToMutate (i + 4) b;
-  set vertexArrayToMutate (i + 5) 1.;
+  set vertexArrayToMutate (i + 5) a;
   set vertexArrayToMutate (i + 6) 0.0;
   set vertexArrayToMutate (i + 7) 0.0;
   set vertexArrayToMutate (i + 8) x2;
@@ -402,7 +415,7 @@ let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b} => {
   set vertexArrayToMutate (i + 10) r;
   set vertexArrayToMutate (i + 11) g;
   set vertexArrayToMutate (i + 12) b;
-  set vertexArrayToMutate (i + 13) 1.;
+  set vertexArrayToMutate (i + 13) a;
   set vertexArrayToMutate (i + 14) 0.0;
   set vertexArrayToMutate (i + 15) 0.0;
   set vertexArrayToMutate (i + 16) x3;
@@ -410,7 +423,7 @@ let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b} => {
   set vertexArrayToMutate (i + 18) r;
   set vertexArrayToMutate (i + 19) g;
   set vertexArrayToMutate (i + 20) b;
-  set vertexArrayToMutate (i + 21) 1.;
+  set vertexArrayToMutate (i + 21) a;
   set vertexArrayToMutate (i + 22) 0.0;
   set vertexArrayToMutate (i + 23) 0.0;
   let ii = i / vertexSize;
@@ -430,10 +443,8 @@ let drawLine p1::(xx1, yy1) p2::(xx2, yy2) ::color ::width ::project env => {
   let radius = width /. 2.;
   let xthing = dy /. mag *. radius;
   let ything = -. dx /. mag *. radius;
-  let (projectx, projecty) = switch project {
-  | true => (dx /. mag *. radius, xthing)
-  | false => (0.,0.)
-  };
+  let (projectx, projecty) =
+    project ? (dx /. mag *. radius, xthing) : (0., 0.);
   let x1 = xx2 +. xthing +. projectx;
   let y1 = yy2 +. ything +. projecty;
   let x2 = xx1 +. xthing -. projectx;
@@ -460,7 +471,7 @@ let drawArc
     (stop: float)
     (isPie: bool)
     (matrix: array float)
-    {r, g, b} => {
+    {r, g, b, a} => {
   let transform = Matrix.matptmul matrix;
   let noOfFans = int_of_float (radx +. rady) / 4 + 10;
   maybeFlushBatch texture::None vert::(8 * noOfFans) el::(3 * noOfFans) env;
@@ -476,7 +487,8 @@ let drawArc
   let start_i =
     if isPie {
       /* Start one earlier and force the first point to be the center */
-      int_of_float (start /. anglePerFan) - 2
+      int_of_float (start /. anglePerFan)
+      - 2
     } else {
       int_of_float (start /. anglePerFan) - 1
     };
@@ -504,7 +516,7 @@ let drawArc
     set verticesData (ii + 2) r;
     set verticesData (ii + 3) g;
     set verticesData (ii + 4) b;
-    set verticesData (ii + 5) 1.0;
+    set verticesData (ii + 5) a;
     set verticesData (ii + 6) 0.0;
     set verticesData (ii + 7) 0.0;
     /* For the first three vertices, we don't do any deduping. Then for the subsequent ones, we'll actually
@@ -541,7 +553,7 @@ let drawArcStroke
     (isOpen: bool)
     (isPie: bool)
     (matrix: array float)
-    ({r, g, b} as strokeColor)
+    ({r, g, b, a} as strokeColor)
     strokeWidth => {
   let transform = Matrix.matptmul matrix;
   let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
@@ -578,7 +590,7 @@ let drawArcStroke
     set verticesData (ii + 2) r;
     set verticesData (ii + 3) g;
     set verticesData (ii + 4) b;
-    set verticesData (ii + 5) 1.0;
+    set verticesData (ii + 5) a;
     set verticesData (ii + 6) 0.0;
     set verticesData (ii + 7) 0.0;
     let ii = ii + vertexSize;
@@ -587,7 +599,7 @@ let drawArcStroke
     set verticesData (ii + 2) r;
     set verticesData (ii + 3) g;
     set verticesData (ii + 4) b;
-    set verticesData (ii + 5) 1.0;
+    set verticesData (ii + 5) a;
     set verticesData (ii + 6) 0.0;
     set verticesData (ii + 7) 0.0;
     env.batch.vertexPtr = env.batch.vertexPtr + vertexSize * 2;
@@ -702,7 +714,7 @@ let loadImage (env: glEnv) filename :imageT => {
 };
 
 let drawImage
-    {width:imgw, height:imgh, textureBuffer}
+    {width: imgw, height: imgh, textureBuffer}
     ::x
     ::y
     ::width

--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -788,7 +788,8 @@ let drawImage
 let resetSize env width height => {
   env.size.width = width;
   env.size.height = height;
-  Gl.viewport context::env.gl x::0 y::0 ::width ::height;
+  let (pixelWidth, pixelHeight) = Gl.Window.(getPixelWidth env.window, getPixelHeight env.window);
+  Gl.viewport context::env.gl x::0 y::0 width::pixelWidth height::pixelHeight;
   Gl.clearColor context::env.gl r::0. g::0. b::0. a::1.;
   Gl.Mat4.ortho
     out::env.camera.projectionMatrix

--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -175,7 +175,7 @@ let createCanvas window (height: int) (width: int) :glEnv => {
     keyboard: {keyCode: Reprocessing_Events.Nothing},
     mouse: {pos: (0, 0), prevPos: (0, 0), pressed: false},
     style: {
-      fillColor: Some {r: 0, g: 0, b: 0, a: 1.},
+      fillColor: Some {r: 0., g: 0., b: 0., a: 1.},
       strokeWeight: 3,
       strokeCap: Round,
       strokeColor: None
@@ -314,8 +314,6 @@ let maybeFlushBatch ::texture ::el ::vert env =>
     flushGlobalBatch env
   };
 
-let toColorFloat i => float_of_int i /. 255.;
-
 /*
  * This array packs all of the values that the shaders need: vertices, colors and texture coordinates.
  * We put them all in one as an optimization, so there are less back and forths between us and the GPU.
@@ -348,7 +346,6 @@ let addRectToGlobalBatch
     color::{r, g, b, a} => {
   maybeFlushBatch texture::None el::6 vert::32 env;
   let set = Gl.Bigarray.set;
-  let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
   let i = env.batch.vertexPtr;
   let vertexArrayToMutate = env.batch.vertexArray;
   set vertexArrayToMutate (i + 0) x1;
@@ -399,7 +396,6 @@ let addRectToGlobalBatch
 let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b, a} => {
   maybeFlushBatch texture::None vert::3 el::24 env;
   let set = Gl.Bigarray.set;
-  let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
   let i = env.batch.vertexPtr;
   let vertexArrayToMutate = env.batch.vertexArray;
   set vertexArrayToMutate (i + 0) x1;
@@ -477,7 +473,6 @@ let drawArc
   maybeFlushBatch texture::None vert::(8 * noOfFans) el::(3 * noOfFans) env;
   let pi = 4.0 *. atan 1.0;
   let anglePerFan = 2. *. pi /. float_of_int noOfFans;
-  let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
   let verticesData = env.batch.vertexArray;
   let elementData = env.batch.elementArray;
   let set = Gl.Bigarray.set;
@@ -556,7 +551,6 @@ let drawArcStroke
     ({r, g, b, a} as strokeColor)
     strokeWidth => {
   let transform = Matrix.matptmul matrix;
-  let (r, g, b) = (toColorFloat r, toColorFloat g, toColorFloat b);
   let verticesData = env.batch.vertexArray;
   let elementData = env.batch.elementArray;
   let noOfFans = int_of_float (radx +. rady) / 4 + 10;
@@ -788,7 +782,8 @@ let drawImage
 let resetSize env width height => {
   env.size.width = width;
   env.size.height = height;
-  let (pixelWidth, pixelHeight) = Gl.Window.(getPixelWidth env.window, getPixelHeight env.window);
+  let (pixelWidth, pixelHeight) =
+    Gl.Window.(getPixelWidth env.window, getPixelHeight env.window);
   Gl.viewport context::env.gl x::0 y::0 width::pixelWidth height::pixelHeight;
   Gl.clearColor context::env.gl r::0. g::0. b::0. a::1.;
   Gl.Mat4.ortho

--- a/src/Reprocessing_Utils.re
+++ b/src/Reprocessing_Utils.re
@@ -4,8 +4,6 @@ let foi = float_of_int;
 
 let lookup_table: ref (array int) = ref [||];
 
-let color ::r ::g ::b ::a=1. () :colorT => {r, g, b, a};
-
 /*Calculation Functions*/
 let round i => floor (i +. 0.5);
 
@@ -81,9 +79,9 @@ let magf vec => distf p1::(0., 0.) p2::vec;
 let mag vec => dist p1::(0, 0) p2::vec;
 
 let lerpColor ::low ::high ::value => {
-  r: lerp low::low.r high::high.r ::value,
-  g: lerp low::low.g high::high.g ::value,
-  b: lerp low::low.b high::high.b ::value,
+  r: lerpf low::low.r high::high.r ::value,
+  g: lerpf low::low.g high::high.g ::value,
+  b: lerpf low::low.b high::high.b ::value,
   a: lerpf low::low.a high::high.a ::value
 };
 
@@ -177,3 +175,12 @@ let noiseSeed seed => {
 };
 
 let split = Reprocessing_Common.split;
+
+let color ::r ::g ::b ::a :colorT => {
+  r: norm value::(float_of_int r) low::0. high::1.,
+  g: norm value::(float_of_int g) low::0. high::1.,
+  b: norm value::(float_of_int b) low::0. high::1.,
+  a: norm value::(float_of_int a) low::0. high::1.
+};
+
+let colorf ::r ::g ::b ::a :colorT => {r, g, b, a};

--- a/src/Reprocessing_Utils.re
+++ b/src/Reprocessing_Utils.re
@@ -4,7 +4,7 @@ let foi = float_of_int;
 
 let lookup_table: ref (array int) = ref [||];
 
-let color ::r ::g ::b :colorT => {r, g, b};
+let color ::r ::g ::b ::a=1. () :colorT => {r, g, b, a};
 
 /*Calculation Functions*/
 let round i => floor (i +. 0.5);
@@ -17,7 +17,9 @@ let rec pow ::base ::exp =>
   | 1 => base
   | n =>
     let b = pow ::base exp::(n / 2);
-    b * b * (
+    b
+    * b
+    * (
       if (n mod 2 == 0) {
         1
       } else {
@@ -81,7 +83,8 @@ let mag vec => dist p1::(0, 0) p2::vec;
 let lerpColor ::low ::high ::value => {
   r: lerp low::low.r high::high.r ::value,
   g: lerp low::low.g high::high.g ::value,
-  b: lerp low::low.b high::high.b ::value
+  b: lerp low::low.b high::high.b ::value,
+  a: lerpf low::low.a high::high.a ::value
 };
 
 let degrees x => 180.0 /. Reprocessing_Constants.pi *. x;

--- a/src/Reprocessing_Utils.rei
+++ b/src/Reprocessing_Utils.rei
@@ -1,10 +1,20 @@
-/** Creates colors for storing in variables of the color datatype. */
+/** Creates colors for storing in variables of the color datatype.
+  *
+  * Components should be in the range 0 to 255 (or 0x00 to 0xFF).
+ */
 let color:
-  r::int =>
-  g::int =>
-  b::int =>
-  a::float? =>
-  unit =>
+  r::int => g::int => b::int => a::int => Reprocessing_Types.Types.colorT;
+
+
+/** Creates colors for storing in variables of the color datatype.
+  *
+  * Components should be in the range 0.0 to 1.0.
+ */
+let colorf:
+  r::float =>
+  g::float =>
+  b::float =>
+  a::float =>
   Reprocessing_Types.Types.colorT;
 
 

--- a/src/Reprocessing_Utils.rei
+++ b/src/Reprocessing_Utils.rei
@@ -1,21 +1,30 @@
 /** Creates colors for storing in variables of the color datatype. */
-let color: r::int => g::int => b::int => Reprocessing_Types.Types.colorT;
+let color:
+  r::int =>
+  g::int =>
+  b::int =>
+  a::float? =>
+  unit =>
+  Reprocessing_Types.Types.colorT;
+
 
 /** Calculates the integer closest to the input. For example,
   * `round 133.8` returns the value 134.
-*/
+ */
 let round: float => float;
+
 
 /** Squares a number (multiplies a number by itself). The result is always a
   * positive number, as multiplying two negative numbers always yields a
   * positive result.
-*/
+ */
 let sq: int => int;
+
 
 /** Facilitates exponential expressions. The pow() function is an efficient
   * way of multiplying numbers by themselves (or their reciprocals) in large
   * quantities.
-*/
+ */
 let pow: base::int => exp::int => int;
 
 
@@ -24,9 +33,9 @@ let constrain: amt::'a => low::'a => high::'a => 'a;
 
 
 /** Re-maps a number from one range to another.
-   * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
-   * would give 15.
-   * Useful for scaling values.
+  * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
+  * would give 15.
+  * Useful for scaling values.
  */
 let remapf:
   value::float =>
@@ -38,77 +47,77 @@ let remapf:
 
 
 /** Re-maps a number from one range to another.
-   * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
-   * would give 15.
-   * Useful for scaling values.
-   *
-   * This is the same as `remapf`, but converts all its integer arguments to floats
-   * as a convenience.
+  * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
+  * would give 15.
+  * Useful for scaling values.
+  *
+  * This is the same as `remapf`, but converts all its integer arguments to floats
+  * as a convenience.
  */
 let remap:
   value::int => low1::int => high1::int => low2::int => high2::int => int;
 
 
 /** Normalizes a number from another range into a value between 0 and 1.
-   * Identical to `remap ::value ::low ::high 0. 1.`
+  * Identical to `remap ::value ::low ::high 0. 1.`
  */
 let norm: value::float => low::float => high::float => float;
 
 
 /** Generates random numbers. Each time the `randomf` function is called, it
-   * returns an unexpected value within the specified range. The top number is
-   * not included.
+  * returns an unexpected value within the specified range. The top number is
+  * not included.
  */
 let randomf: min::float => max::float => float;
 
 
 /** Generates random numbers. Each time the `random` function is called, it
-   * returns an unexpected value within the specified range. The top number is
-   * not included.
-   *
-   * This is the same as `randomf`, but converts all its integer arguments to floats
-   * as a convenience.
+  * returns an unexpected value within the specified range. The top number is
+  * not included.
+  *
+  * This is the same as `randomf`, but converts all its integer arguments to floats
+  * as a convenience.
  */
 let random: min::int => max::int => int;
 
 
 /** Sets the seed value for `random` and `randomf`. By default, `random`
-   * produces different results each time the program is run. Set the
-   * seed parameter to a constant to return the same pseudo-random
-   * numbers each time the software is run.
-   * This is equivalent to setting Random.init in ocaml/reason.
+  * produces different results each time the program is run. Set the
+  * seed parameter to a constant to return the same pseudo-random
+  * numbers each time the software is run.
+  * This is equivalent to setting Random.init in ocaml/reason.
  */
 let randomSeed: int => unit;
 
 
 /** Returns a float from a random series of numbers having a mean of 0 and
-   * standard deviation of 1. Each time the `randomGaussian` function is called,
-   * it returns a number fitting a Gaussian, or normal, distribution. There is
-   * theoretically no minimum or maximum value that `randomGaussian might
-   * return. Rather, there is just a very low probability that values far from
-   * the mean will be returned; and a higher probability that numbers near the
-   * mean will be returned.
+  * standard deviation of 1. Each time the `randomGaussian` function is called,
+  * it returns a number fitting a Gaussian, or normal, distribution. There is
+  * theoretically no minimum or maximum value that `randomGaussian might
+  * return. Rather, there is just a very low probability that values far from
+  * the mean will be returned; and a higher probability that numbers near the
+  * mean will be returned.
  */
 let randomGaussian: unit => float;
 
 
 /** Calculates a number between two numbers at a specific increment. The
-   * amt parameter is the amount to interpolate between the two values where 0.0
-   * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
-   * in between, etc. The lerp function is convenient for creating motion along a
-   * straight path and for drawing dotted lines.
+  * amt parameter is the amount to interpolate between the two values where 0.0
+  * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
+  * in between, etc. The lerp function is convenient for creating motion along a
+  * straight path and for drawing dotted lines.
  */
 let lerpf: low::float => high::float => value::float => float;
 
 
 /** Calculates a number between two numbers at a specific increment. The
-   * amt parameter is the amount to interpolate between the two values where 0.0
-   * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
-   * in between, etc. The lerp function is convenient for creating motion along a
-   * straight path and for drawing dotted lines.
-   *
-   * This is the same as `lerpf`, but converts all its integer arguments to floats
-   * as a convenience.
+  * amt parameter is the amount to interpolate between the two values where 0.0
+  * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
+  * in between, etc. The lerp function is convenient for creating motion along a
+  * straight path and for drawing dotted lines.
+  *
+  * This is the same as `lerpf`, but converts all its integer arguments to floats
+  * as a convenience.
  */
 let lerp: low::int => high::int => value::float => int;
 
@@ -118,84 +127,93 @@ let lerpColor:
   value::float =>
   Reprocessing_Types.Types.colorT;
 
+
 /** Calculates the distance between two points. */
 let distf: p1::(float, float) => p2::(float, float) => float;
+
 
 /** Calculates the distance between two points.
   *
   * This is the same as `distf`, but converts all its integer arguments to floats
   * as a convenience.
-*/
+ */
 let dist: p1::(int, int) => p2::(int, int) => float;
 
-/** Calculates the magnitude (or length) of a vector. A vector is a direction
- * in space commonly used in computer graphics and linear algebra. Because it
- * has no "start" position, the magnitude of a vector can be thought of as the
- * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
- * shortcut for writing `dist (0, 0) (x, y)`.
-*/
-let magf: (float, float) => float;
 
 /** Calculates the magnitude (or length) of a vector. A vector is a direction
- * in space commonly used in computer graphics and linear algebra. Because it
- * has no "start" position, the magnitude of a vector can be thought of as the
- * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
- * shortcut for writing `dist (0, 0) (x, y)`.
+  * in space commonly used in computer graphics and linear algebra. Because it
+  * has no "start" position, the magnitude of a vector can be thought of as the
+  * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
+  * shortcut for writing `dist (0, 0) (x, y)`.
+ */
+let magf: (float, float) => float;
+
+
+/** Calculates the magnitude (or length) of a vector. A vector is a direction
+  * in space commonly used in computer graphics and linear algebra. Because it
+  * has no "start" position, the magnitude of a vector can be thought of as the
+  * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
+  * shortcut for writing `dist (0, 0) (x, y)`.
   *
   * This is the same as `magf`, but converts all its integer arguments to floats
   * as a convenience.
-*/
+ */
 let mag: (int, int) => float;
+
 
 /** Converts a radian measurement to its corresponding value in degrees.
   * Radians and degrees are two ways of measuring the same thing. There are 360
   * degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 =
   * 1.5707964. All trigonometric functions require their parameters to be
   * specified in radians.
-*/
+ */
 let degrees: float => float;
+
 
 /** Converts a degree measurement to its corresponding value in radians.
   * Radians and degrees are two ways of measuring the same thing. There are 360
   * degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 =
   * 1.5707964. All trigonometric functions require their parameters to be
   * specified in radians.
-*/
+ */
 let radians: float => float;
 
+
 /** Returns the Perlin noise value at specified coordinates. Perlin noise is a
- * random sequence generator producing a more natural, harmonic succession of
- * numbers than that of the standard random() function. It was developed by Ken
- * Perlin in the 1980s and has been used in graphical applications to generate
- * procedural textures, shapes, terrains, and other seemingly organic forms.
- *
- * In contrast to the random() function, Perlin noise is defined in an infinite
- * n-dimensional space, in which each pair of coordinates corresponds to a
- * fixed semi-random value (fixed only for the lifespan of the program). The
- * resulting value will always be between 0.0 and 1.0. The noise value can be
- * animated by moving through the noise space.
- *
- * The actual noise structure is similar to that of an audio signal, in respect
- * to the function's use of frequencies. Similar to the concept of harmonics in
- * physics, Perlin noise is computed over several octaves which are added together
- * for the final result.
- *
- * Another way to adjust the character of the resulting sequence is the scale of
- * the input coordinates. As the function works within an infinite space, the
- * value of the coordinates doesn't matter as such; only the distance between
+  * random sequence generator producing a more natural, harmonic succession of
+  * numbers than that of the standard random() function. It was developed by Ken
+  * Perlin in the 1980s and has been used in graphical applications to generate
+  * procedural textures, shapes, terrains, and other seemingly organic forms.
+  *
+  * In contrast to the random() function, Perlin noise is defined in an infinite
+  * n-dimensional space, in which each pair of coordinates corresponds to a
+  * fixed semi-random value (fixed only for the lifespan of the program). The
+  * resulting value will always be between 0.0 and 1.0. The noise value can be
+  * animated by moving through the noise space.
+  *
+  * The actual noise structure is similar to that of an audio signal, in respect
+  * to the function's use of frequencies. Similar to the concept of harmonics in
+  * physics, Perlin noise is computed over several octaves which are added together
+  * for the final result.
+  *
+  * Another way to adjust the character of the resulting sequence is the scale of
+  * the input coordinates. As the function works within an infinite space, the
+  * value of the coordinates doesn't matter as such; only the distance between
   * successive coordinates is important (such as when using noise() within a loop).
   * As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
-*/
+ */
 let noise: float => float => float => float;
 
+
 /** Sets the seed value for `noise`.  This will also affect the
-   * seed value for `random` and `randomf`.
+  * seed value for `random` and `randomf`.
  */
 let noiseSeed: int => unit;
+
 
 /** The `split` function breaks a string into pieces using a character
   * as the delimiter. The sep parameter specifies the character
   * that mark the boundaries between each piece. A list is returned
   * that contains each of the pieces.
-*/
+ */
 let split: string => sep::char => list string;


### PR DESCRIPTION
This adds an alpha channel to the color type and to Utils.color.

Caveats:

- Alpha is a float instead of an int, mostly because it seemed more natural to me. I suppose it could also be an int in (0,255) by the same logic that the rgb channels are already. I don't have a very strong preference.
- I gave the alpha channel a default of `1.0` in `Utils.color`. A side effect of this is `Utils.color` now requires a `()` to terminate the named args.
- Strokes get double painted at the corners still. This works for fills at least for now.
- Lots of noise is included here since I've updated to refmt (reason-cli) 1.13.7, which tries to put each in a chain of operators on its own line. I can back these out if that's preferred.

Also, I fixed a hidpi bug (I think) that was making rendering weird on my new retina laptop (all rendering to my reprocessing env was constrained within the bottom left quadrant of the otherwise black canvas).
