### PR TITLE
Upgrade to Reason 3 syntax

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -10,5 +10,6 @@
     {"kind": "bytecode", "main": "Index"},
     {"kind": "js", "main": "Index"}
   ],
+  "reason": 3
 }
 

--- a/examples/index.re
+++ b/examples/index.re
@@ -12,79 +12,77 @@ type dropT = {
   time: int
 };
 
-let make w (ymin, ymax) time => {
-  let z = Utils.random min::0 max::20;
+let make = (w, (ymin, ymax), time) => {
+  let z = Utils.random(~min=0, ~max=20);
   {
-    x: Utils.random min::0 max::w,
-    y: Utils.random min::ymin max::ymax,
+    x: Utils.random(~min=0, ~max=w),
+    y: Utils.random(~min=ymin, ~max=ymax),
     z,
-    len: Utils.remap value::z low1::0 high1::20 low2::10 high2::20,
-    yspeed: Utils.remap value::z low1::0 high1::20 low2::5 high2::15,
+    len: Utils.remap(~value=z, ~low1=0, ~high1=20, ~low2=10, ~high2=20),
+    yspeed: Utils.remap(~value=z, ~low1=0, ~high1=20, ~low2=5, ~high2=15),
     color:
-      Utils.lerpColor
-        low::Constants.white
-        high::(Utils.color r::138 g::43 b::226 a::255)
-        value::(Utils.randomf min::0.3 max::1.),
+      Utils.lerpColor(
+        ~low=Constants.white,
+        ~high=Utils.color(~r=138, ~g=43, ~b=226, ~a=255),
+        ~value=Utils.randomf(~min=0.3, ~max=1.)
+      ),
     time
   }
 };
 
 type state = {
-  lst: array dropT,
+  lst: array(dropT),
   running: bool,
   time: int
 };
 
-let setup env => {
-  Env.size width::640 height::360 env;
-  Draw.fill (Utils.color r::255 g::0 b::0 a::255) env;
-  Draw.noStroke env;
-  let lst = Array.init 500 (fun _ => make (Env.width env) ((-500), (-50)) 0);
+let setup = (env) => {
+  Env.size(~width=640, ~height=360, env);
+  Draw.fill(Utils.color(~r=255, ~g=0, ~b=0, ~a=255), env);
+  Draw.noStroke(env);
+  let lst = Array.init(500, (_) => make(Env.width(env), ((-500), (-50)), 0));
   {lst, time: 0, running: true}
 };
 
-let draw {lst, running, time} env => {
-  Draw.background (Utils.color r::230 g::230 b::250 a::255) env;
-  Draw.fill (Utils.color r::255 g::0 b::0 a::255) env;
-  Utils.randomSeed time;
+let draw = ({lst, running, time}, env) => {
+  Draw.background(Utils.color(~r=230, ~g=230, ~b=250, ~a=255), env);
+  Draw.fill(Utils.color(~r=255, ~g=0, ~b=0, ~a=255), env);
+  Utils.randomSeed(time);
   let lst =
-    Array.map
-      (
-        fun drop =>
-          switch (drop.y + drop.yspeed * (time - drop.time)) {
-          | y when y > Env.height env + 500 =>
-            make (Env.width env) ((-500), (-50)) time
-          | y when y < (-500) =>
-            make
-              (Env.width env) (Env.height env + 50, Env.height env + 500) time
-          | _ => drop
-          }
+    Array.map(
+      (drop) =>
+        switch (drop.y + drop.yspeed * (time - drop.time)) {
+        | y when y > Env.height(env) + 500 => make(Env.width(env), ((-500), (-50)), time)
+        | y when y < (-500) =>
+          make(Env.width(env), (Env.height(env) + 50, Env.height(env) + 500), time)
+        | _ => drop
+        },
+      lst
+    );
+  Array.iter(
+    (drop) => {
+      Draw.fill(drop.color, env);
+      Draw.ellipse(
+        ~center=(drop.x, drop.y + drop.yspeed * (time - drop.time)),
+        ~radx=Utils.remap(~value=drop.z, ~low1=0, ~high1=20, ~low2=1, ~high2=3),
+        ~rady=drop.yspeed,
+        env
       )
-      lst;
-  Array.iter
-    (
-      fun drop => {
-        Draw.fill drop.color env;
-        Draw.ellipse
-          center::(drop.x, drop.y + drop.yspeed * (time - drop.time))
-          radx::(Utils.remap value::drop.z low1::0 high1::20 low2::1 high2::3)
-          rady::drop.yspeed
-          env
-      }
-    )
-    lst;
+    },
+    lst
+  );
   {lst, running, time: running ? time + 1 : time}
 };
 
-let mouseDown state _env => {...state, running: false};
+let mouseDown = (state, _env) => {...state, running: false};
 
-let mouseUp state _env => {...state, running: true};
+let mouseUp = (state, _env) => {...state, running: true};
 
-let mouseDragged ({time} as state) env => {
-  let (pmouseX, _) = Env.pmouse env;
-  let (mouseX, _) = Env.mouse env;
+let mouseDragged = ({time} as state, env) => {
+  let (pmouseX, _) = Env.pmouse(env);
+  let (mouseX, _) = Env.mouse(env);
   let newTime = time - (pmouseX - mouseX);
   {...state, time: newTime}
 };
 
-run ::setup ::draw ::mouseDown ::mouseUp ::mouseDragged ();
+run(~setup, ~draw, ~mouseDown, ~mouseUp, ~mouseDragged, ());

--- a/examples/noise.re
+++ b/examples/noise.re
@@ -6,32 +6,31 @@ open Reprocessing.Env;
 
 open Reprocessing.Constants;
 
-let setup env => {
-  size width::640 height::640 env;
-  noStroke env;
+let setup = (env) => {
+  size(~width=640, ~height=640, env);
+  noStroke(env);
   0.01
 };
 
-let draw z env => {
-  background (color r::230 g::230 b::250 a::255) env;
+let draw = (z, env) => {
+  background(color(~r=230, ~g=230, ~b=250, ~a=255), env);
   let res = 100;
-  let w = float_of_int (width env) /. float_of_int res;
-  let h = float_of_int (height env) /. float_of_int res;
-  for i in 0 to (res - 1) {
-    for j in 0 to (res - 1) {
-      fill
-        (
-          lerpColor
-            low::white
-            high::black
-            value::(noise (0.03 *. float_of_int i) (0.03 *. float_of_int j) z)
-        )
-        env;
-      rectf
-        pos::(float_of_int i *. w, float_of_int j *. h) width::w height::h env
+  let w = float_of_int(width(env)) /. float_of_int(res);
+  let h = float_of_int(height(env)) /. float_of_int(res);
+  for (i in 0 to res - 1) {
+    for (j in 0 to res - 1) {
+      fill(
+        lerpColor(
+          ~low=white,
+          ~high=black,
+          ~value=noise(0.03 *. float_of_int(i), 0.03 *. float_of_int(j), z)
+        ),
+        env
+      );
+      rectf(~pos=(float_of_int(i) *. w, float_of_int(j) *. h), ~width=w, ~height=h, env)
     }
   };
   z +. 0.05
 };
 
-Reprocessing.run ::setup ::draw ();
+Reprocessing.run(~setup, ~draw, ());

--- a/examples/redsquare.re
+++ b/examples/redsquare.re
@@ -8,30 +8,27 @@ type state = (int, int);
 
 let squareSize = 300;
 
-let setup env => {
-  size width::600 height::600 env;
-  fill Reprocessing.Constants.red env;
+let setup = (env) => {
+  size(~width=600, ~height=600, env);
+  fill(Reprocessing.Constants.red, env);
   (0, 0)
 };
 
-let draw squarePos env => {
-  background (color r::150 g::255 b::255 a::255) env;
+let draw = (squarePos, env) => {
+  background(color(~r=150, ~g=255, ~b=255, ~a=255), env);
   let (sx, sy) = squarePos;
-  let (px, py) = pmouse env;
+  let (px, py) = pmouse(env);
   let (x, y) as squarePos =
-    if (
-      mousePressed env &&
-      px > sx && px < sx + squareSize && py > sy && py < sy + squareSize
-    ) {
-      let (mx, my) = mouse env;
+    if (mousePressed(env) && px > sx && px < sx + squareSize && py > sy && py < sy + squareSize) {
+      let (mx, my) = mouse(env);
       let dx = mx - px;
       let dy = my - py;
       (sx + dx, sy + dy)
     } else {
       squarePos
     };
-  rect pos::(x, y) width::squareSize height::squareSize env;
+  rect(~pos=(x, y), ~width=squareSize, ~height=squareSize, env);
   squarePos
 };
 
-Reprocessing.run ::setup ::draw ();
+Reprocessing.run(~setup, ~draw, ());

--- a/src/Reprocessing.re
+++ b/src/Reprocessing.re
@@ -16,85 +16,88 @@ module Events = Reprocessing_Events;
 
 include Reprocessing_Types.Types;
 
-let afterDraw f (env: Common.glEnv) => {
+let afterDraw = (f, env: Common.glEnv) => {
   open Common;
-  let rate = int_of_float (1000. /. f);
+  let rate = int_of_float(1000. /. f);
   env.mouse.prevPos = env.mouse.pos;
   env.frame = {count: env.frame.count + 1, rate, deltaTime: f /. 1000.};
-  Matrix.copyInto src::Matrix.identity dst::env.matrix;
+  Matrix.copyInto(~src=Matrix.identity, ~dst=env.matrix);
   /* Flush the batching buffer at the end of every frame. */
   if (env.batch.elementPtr > 0) {
-    flushGlobalBatch env
+    flushGlobalBatch(env)
   }
 };
 
-let run
-    ::setup
-    ::draw=?
-    ::mouseMove=?
-    ::mouseDragged=?
-    ::mouseDown=?
-    ::mouseUp=?
-    ::keyPressed=?
-    ::keyReleased=?
-    ::keyTyped=?
-    () => {
-  Random.self_init ();
-  Reprocessing_Utils.noiseSeed (
-    Random.int (Reprocessing_Utils.pow base::2 exp::(30 - 1))
-  );
+let run =
+    (
+      ~setup,
+      ~draw=?,
+      ~mouseMove=?,
+      ~mouseDragged=?,
+      ~mouseDown=?,
+      ~mouseUp=?,
+      ~keyPressed=?,
+      ~keyReleased=?,
+      ~keyTyped=?,
+      ()
+    ) => {
+  Random.self_init();
+  Reprocessing_Utils.noiseSeed(Random.int(Reprocessing_Utils.pow(~base=2, ~exp=30 - 1)));
   let env =
-    Reprocessing_Internal.createCanvas
-      (Reprocessing_ClientWrapper.init argv::Sys.argv) 200 200;
-  let userState = ref (setup env);
+    Reprocessing_Internal.createCanvas(Reprocessing_ClientWrapper.init(~argv=Sys.argv), 200, 200);
+  let userState = ref(setup(env));
 
-  /** This is a basically a hack to get around the default behavior of drawing something inside setup.
-      Because OpenGL uses double buffering, drawing in setup will result in a flickering shape, as the data
-      will only be in one buffer. To circumvent this we draw, read the pixel data and store that array, advance
-      one frame and then paint that array as a texture on top before calling draw for the 2nd time. This ensures
-      that both internal buffers contain the same data. **/
+  /*** This is a basically a hack to get around the default behavior of drawing something inside setup.
+       Because OpenGL uses double buffering, drawing in setup will result in a flickering shape, as the data
+       will only be in one buffer. To circumvent this we draw, read the pixel data and store that array, advance
+       one frame and then paint that array as a texture on top before calling draw for the 2nd time. This ensures
+       that both internal buffers contain the same data. **/
   let reDrawPreviousBufferOnSecondFrame = {
     open Common;
-    let width = Gl.Window.getWidth env.window;
-    let height = Gl.Window.getHeight env.window;
-    let data = Gl.readPixels_RGBA context::env.gl x::0 y::0 ::width ::height;
-    let textureBuffer = Gl.createTexture context::env.gl;
-    Gl.bindTexture
-      context::env.gl target::RGLConstants.texture_2d texture::textureBuffer;
-    Gl.texImage2D_RGBA
-      context::env.gl
-      target::RGLConstants.texture_2d
-      level::0
-      ::width
-      ::height
-      border::0
-      ::data;
-    Gl.texParameteri
-      context::env.gl
-      target::RGLConstants.texture_2d
-      pname::RGLConstants.texture_mag_filter
-      param::RGLConstants.linear;
-    Gl.texParameteri
-      context::env.gl
-      target::RGLConstants.texture_2d
-      pname::RGLConstants.texture_min_filter
-      param::RGLConstants.linear;
-    Gl.texParameteri
-      context::env.gl
-      target::RGLConstants.texture_2d
-      pname::RGLConstants.texture_wrap_s
-      param::RGLConstants.clamp_to_edge;
-    Gl.texParameteri
-      context::env.gl
-      target::RGLConstants.texture_2d
-      pname::RGLConstants.texture_wrap_t
-      param::RGLConstants.clamp_to_edge;
-    fun () => {
+    let width = Gl.Window.getWidth(env.window);
+    let height = Gl.Window.getHeight(env.window);
+    let data = Gl.readPixels_RGBA(~context=env.gl, ~x=0, ~y=0, ~width, ~height);
+    let textureBuffer = Gl.createTexture(~context=env.gl);
+    Gl.bindTexture(~context=env.gl, ~target=RGLConstants.texture_2d, ~texture=textureBuffer);
+    Gl.texImage2D_RGBA(
+      ~context=env.gl,
+      ~target=RGLConstants.texture_2d,
+      ~level=0,
+      ~width,
+      ~height,
+      ~border=0,
+      ~data
+    );
+    Gl.texParameteri(
+      ~context=env.gl,
+      ~target=RGLConstants.texture_2d,
+      ~pname=RGLConstants.texture_mag_filter,
+      ~param=RGLConstants.linear
+    );
+    Gl.texParameteri(
+      ~context=env.gl,
+      ~target=RGLConstants.texture_2d,
+      ~pname=RGLConstants.texture_min_filter,
+      ~param=RGLConstants.linear
+    );
+    Gl.texParameteri(
+      ~context=env.gl,
+      ~target=RGLConstants.texture_2d,
+      ~pname=RGLConstants.texture_wrap_s,
+      ~param=RGLConstants.clamp_to_edge
+    );
+    Gl.texParameteri(
+      ~context=env.gl,
+      ~target=RGLConstants.texture_2d,
+      ~pname=RGLConstants.texture_wrap_t,
+      ~param=RGLConstants.clamp_to_edge
+    );
+    () => {
       let (x, y) = (0, 0);
       let (x1, y1) = (float_of_int @@ x + width, float_of_int @@ y);
-      let (x2, y2) = (float_of_int x, float_of_int @@ y);
+      let (x2, y2) = (float_of_int(x), float_of_int @@ y);
       let (x3, y3) = (float_of_int @@ x + width, float_of_int @@ y + height);
-      let (x4, y4) = (float_of_int x, float_of_int @@ y + height);
+      let (x4, y4) = (float_of_int(x), float_of_int @@ y + height);
       let verticesColorAndTexture = [|
         x1,
         y1,
@@ -133,104 +136,95 @@ let run
         0.0,
         0.0
       |];
-      drawGeometry
-        vertexArray::(
-          Gl.Bigarray.of_array Gl.Bigarray.Float32 verticesColorAndTexture
-        )
-        elementArray::(
-          Gl.Bigarray.of_array Gl.Bigarray.Uint16 [|0, 1, 2, 1, 2, 3|]
-        )
-        mode::RGLConstants.triangles
-        count::6
-        ::textureBuffer
+      drawGeometry(
+        ~vertexArray=Gl.Bigarray.of_array(Gl.Bigarray.Float32, verticesColorAndTexture),
+        ~elementArray=Gl.Bigarray.of_array(Gl.Bigarray.Uint16, [|0, 1, 2, 1, 2, 3|]),
+        ~mode=RGLConstants.triangles,
+        ~count=6,
+        ~textureBuffer,
         env
+      )
     }
   };
 
-  /** Start the render loop. **/
-  Gl.render
-    window::env.window
-    displayFunc::(
-      fun f => {
+  /*** Start the render loop. **/
+  Gl.render(
+    ~window=env.window,
+    ~displayFunc=
+      (f) => {
         if (env.frame.count === 2) {
-          reDrawPreviousBufferOnSecondFrame ()
+          reDrawPreviousBufferOnSecondFrame()
         };
         switch draw {
-        | Some draw => userState := draw !userState env
+        | Some(draw) => userState := draw(userState^, env)
         | None => ()
         };
-        afterDraw f env
-      }
-    )
-    mouseDown::(
-      fun button::_ state::_ ::x ::y => {
+        afterDraw(f, env)
+      },
+    ~mouseDown=
+      (~button as _, ~state as _, ~x, ~y) => {
         env.mouse.pos = (x, y);
         env.mouse.pressed = true;
         switch mouseDown {
-        | Some mouseDown => userState := mouseDown !userState env
+        | Some(mouseDown) => userState := mouseDown(userState^, env)
         | None => ()
         }
-      }
-    )
-    mouseUp::(
-      fun button::_ state::_ ::x ::y => {
+      },
+    ~mouseUp=
+      (~button as _, ~state as _, ~x, ~y) => {
         env.mouse.pos = (x, y);
         env.mouse.pressed = false;
         switch mouseUp {
-        | Some mouseUp => userState := mouseUp !userState env
+        | Some(mouseUp) => userState := mouseUp(userState^, env)
         | None => ()
         }
-      }
-    )
-    mouseMove::(
-      fun ::x ::y => {
+      },
+    ~mouseMove=
+      (~x, ~y) => {
         env.mouse.pos = (x, y);
-        if env.mouse.pressed {
+        if (env.mouse.pressed) {
           switch mouseDragged {
-          | Some mouseDragged => userState := mouseDragged !userState env
+          | Some(mouseDragged) => userState := mouseDragged(userState^, env)
           | None => ()
           }
         } else {
           switch mouseMove {
-          | Some mouseMove => userState := mouseMove !userState env
+          | Some(mouseMove) => userState := mouseMove(userState^, env)
           | None => ()
           }
         }
-      }
-    )
-    windowResize::(
-      fun () =>
-        if env.size.resizeable {
-          let height = Gl.Window.getHeight env.window;
-          let width = Gl.Window.getWidth env.window;
-          resetSize env width height
+      },
+    ~windowResize=
+      () =>
+        if (env.size.resizeable) {
+          let height = Gl.Window.getHeight(env.window);
+          let width = Gl.Window.getWidth(env.window);
+          resetSize(env, width, height)
         } else {
-          Env.size width::(Env.width env) height::(Env.height env) env
-        }
-    )
-    keyDown::(
-      fun ::keycode ::repeat => {
+          Env.size(~width=Env.width(env), ~height=Env.height(env), env)
+        },
+    ~keyDown=
+      (~keycode, ~repeat) => {
         env.keyboard.keyCode = keycode;
-        if (not repeat) {
+        if (! repeat) {
           switch keyPressed {
-          | Some keyPressed => userState := keyPressed !userState env
+          | Some(keyPressed) => userState := keyPressed(userState^, env)
           | None => ()
           }
         };
         switch keyTyped {
-        | Some keyTyped => userState := keyTyped !userState env
+        | Some(keyTyped) => userState := keyTyped(userState^, env)
         | None => ()
         }
-      }
-    )
-    keyUp::(
-      fun ::keycode => {
+      },
+    ~keyUp=
+      (~keycode) => {
         env.keyboard.keyCode = keycode;
         switch keyReleased {
-        | Some keyReleased => userState := keyReleased !userState env
+        | Some(keyReleased) => userState := keyReleased(userState^, env)
         | None => ()
         }
-      }
-    )
+      },
     ()
+  )
 };

--- a/src/Reprocessing.rei
+++ b/src/Reprocessing.rei
@@ -1,37 +1,44 @@
-/** Contains functions having to do with drawing to the screen */
+/*** Contains functions having to do with drawing to the screen */
 module Draw = Reprocessing_Draw;
 
-/** Contains functions having to do with the environment:
-  * ie window properties, user input
-*/
+
+/*** Contains functions having to do with the environment:
+   * ie window properties, user input
+ */
 module Env = Reprocessing_Env;
 
-/** Contains types for events. */
+
+/*** Contains types for events. */
 module Events = Reprocessing_Events;
 
-/** Contains utility functions */
+
+/*** Contains utility functions */
 module Utils = Reprocessing_Utils;
 
-/** Contains useful constants */
+
+/*** Contains useful constants */
 module Constants = Reprocessing_Constants;
 
 include Reprocessing_Types.TypesT;
 
-/** Entrypoint to the graphics library. The system
-  * is designed for you to return a self-defined 'state'
-  * object from setup, which will then be passed to every
-  * callback you choose to implement. Updating the state
-  * is done by returning a different value from the callback.
-*/
+
+/*** Entrypoint to the graphics library. The system
+   * is designed for you to return a self-defined 'state'
+   * object from setup, which will then be passed to every
+   * callback you choose to implement. Updating the state
+   * is done by returning a different value from the callback.
+ */
 let run:
-  setup::(glEnvT => 'a) =>
-  draw::('a => glEnvT => 'a)? =>
-  mouseMove::('a => glEnvT => 'a)? =>
-  mouseDragged::('a => glEnvT => 'a)? =>
-  mouseDown::('a => glEnvT => 'a)? =>
-  mouseUp::('a => glEnvT => 'a)? =>
-  keyPressed::('a => glEnvT => 'a)? =>
-  keyReleased::('a => glEnvT => 'a)? =>
-  keyTyped::('a => glEnvT => 'a)? =>
-  unit =>
+  (
+    ~setup: glEnvT => 'a,
+    ~draw: ('a, glEnvT) => 'a=?,
+    ~mouseMove: ('a, glEnvT) => 'a=?,
+    ~mouseDragged: ('a, glEnvT) => 'a=?,
+    ~mouseDown: ('a, glEnvT) => 'a=?,
+    ~mouseUp: ('a, glEnvT) => 'a=?,
+    ~keyPressed: ('a, glEnvT) => 'a=?,
+    ~keyReleased: ('a, glEnvT) => 'a=?,
+    ~keyTyped: ('a, glEnvT) => 'a=?,
+    unit
+  ) =>
   unit;

--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -19,10 +19,10 @@ type colorT = {
 };
 
 type styleT = {
-  strokeColor: option colorT,
+  strokeColor: option(colorT),
   strokeWeight: int,
   strokeCap: strokeCapT,
-  fillColor: option colorT
+  fillColor: option(colorT)
 };
 
 type mouseT = {
@@ -56,14 +56,14 @@ type _imageT = {
   width: int
 };
 
-type imageT = ref (option _imageT);
+type imageT = ref(option(_imageT));
 
 type batchT = {
-  vertexArray: Gl.Bigarray.t float Gl.Bigarray.float32_elt,
-  elementArray: Gl.Bigarray.t int Gl.Bigarray.int16_unsigned_elt,
+  vertexArray: Gl.Bigarray.t(float, Gl.Bigarray.float32_elt),
+  elementArray: Gl.Bigarray.t(int, Gl.Bigarray.int16_unsigned_elt),
   mutable vertexPtr: int,
   mutable elementPtr: int,
-  mutable currTex: option Gl.textureT,
+  mutable currTex: option(Gl.textureT),
   nullTex: Gl.textureT
 };
 
@@ -82,85 +82,85 @@ type glEnv = {
   keyboard: keyboardT,
   mouse: mouseT,
   mutable style: styleT,
-  mutable styleStack: list styleT,
+  mutable styleStack: list(styleT),
   mutable frame: frameT,
-  mutable matrix: array float,
-  mutable matrixStack: list (array float),
+  mutable matrix: array(float),
+  mutable matrixStack: list(array(float)),
   size: sizeT
 };
 
 module type ReProcessorT = {
   type t;
   let run:
-    setup::(glEnv => 'a) =>
-    draw::('a => glEnv => 'a)? =>
-    mouseMove::('a => glEnv => 'a)? =>
-    mouseDragged::('a => glEnv => 'a)? =>
-    mouseDown::('a => glEnv => 'a)? =>
-    mouseUp::('a => glEnv => 'a)? =>
-    keyPressed::('a => glEnv => 'a)? =>
-    keyReleased::('a => glEnv => 'a)? =>
-    keyTyped::('a => glEnv => 'a)? =>
-    unit =>
+    (
+      ~setup: glEnv => 'a,
+      ~draw: ('a, glEnv) => 'a=?,
+      ~mouseMove: ('a, glEnv) => 'a=?,
+      ~mouseDragged: ('a, glEnv) => 'a=?,
+      ~mouseDown: ('a, glEnv) => 'a=?,
+      ~mouseUp: ('a, glEnv) => 'a=?,
+      ~keyPressed: ('a, glEnv) => 'a=?,
+      ~keyReleased: ('a, glEnv) => 'a=?,
+      ~keyTyped: ('a, glEnv) => 'a=?,
+      unit
+    ) =>
     unit;
 };
 
 module Stream = {
   type t = (string, int);
   let empty = [];
-  let peekch ((str, i): t) :option char =>
-    if (i < String.length str) {
-      Some str.[i]
+  let peekch = ((str, i): t) : option(char) =>
+    if (i < String.length(str)) {
+      Some(str.[i])
     } else {
       None
     };
-  let popch ((str, i): t) :t => (str, i + 1);
-  let peekn (str, i) len =>
-    if (i + len < String.length str) {
-      Some (String.sub str i len)
+  let popch = ((str, i): t) : t => (str, i + 1);
+  let peekn = ((str, i), len) =>
+    if (i + len < String.length(str)) {
+      Some(String.sub(str, i, len))
     } else {
       None
     };
-  let popn (str, i) len => (str, i + len);
-  let match stream matchstr => {
-    let len = String.length matchstr;
-    switch (peekn stream len) {
-    | Some peek when peek == matchstr => popn stream len
-    | Some peek =>
-      failwith (
-        "Could not match '" ^ matchstr ^ "', got '" ^ peek ^ "' instead."
-      )
-    | None => failwith ("Could not match " ^ matchstr)
+  let popn = ((str, i), len) => (str, i + len);
+  let switch_ = (stream, matchstr) => {
+    let len = String.length(matchstr);
+    switch (peekn(stream, len)) {
+    | Some(peek) when peek == matchstr => popn(stream, len)
+    | Some(peek) =>
+      failwith("Could not match '" ++ (matchstr ++ ("', got '" ++ (peek ++ "' instead."))))
+    | None => failwith("Could not match " ++ matchstr)
     }
   };
-  let charsRemaining (str, i) => String.length str - i;
-  let create (str: string) :t => (str, 0);
+  let charsRemaining = ((str, i)) => String.length(str) - i;
+  let create = (str: string) : t => (str, 0);
 };
 
-let read (name: string) => {
-  let ic = open_in name;
-  let try_read () =>
-    switch (input_line ic) {
+let read = (name: string) => {
+  let ic = open_in(name);
+  let try_read = () =>
+    switch (input_line(ic)) {
     | exception End_of_file => None
-    | x => Some x
+    | x => Some(x)
     };
-  let rec loop acc =>
-    switch (try_read ()) {
-    | Some s => loop [String.make 1 '\n', s, ...acc]
+  let rec loop = (acc) =>
+    switch (try_read()) {
+    | Some(s) => loop([String.make(1, '\n'), s, ...acc])
     | None =>
-      close_in ic;
-      List.rev acc
+      close_in(ic);
+      List.rev(acc)
     };
-  loop [] |> String.concat ""
+  loop([]) |> String.concat("")
 };
 
-let append_char (s: string) (c: char) :string => s ^ String.make 1 c;
+let append_char = (s: string, c: char) : string => s ++ String.make(1, c);
 
-let rec split stream sep accstr acc =>
-  switch (Stream.peekch stream) {
-  | Some c when c == sep => split (Stream.popch stream) sep "" [accstr, ...acc]
-  | Some c => split (Stream.popch stream) sep (append_char accstr c) acc
-  | None => List.rev [accstr, ...acc]
+let rec split = (stream, sep, accstr, acc) =>
+  switch (Stream.peekch(stream)) {
+  | Some(c) when c == sep => split(Stream.popch(stream), sep, "", [accstr, ...acc])
+  | Some(c) => split(Stream.popch(stream), sep, append_char(accstr, c), acc)
+  | None => List.rev([accstr, ...acc])
   };
 
-let split str ::sep => split (Stream.create str) sep "" [];
+let split = (str, ~sep) => split(Stream.create(str), sep, "", []);

--- a/src/Reprocessing_Constants.re
+++ b/src/Reprocessing_Constants.re
@@ -10,7 +10,7 @@ let green = {r: 0., g: 1., b: 0., a: 1.};
 
 let blue = {r: 0., g: 0., b: 1., a: 1.};
 
-let pi = 4.0 *. atan 1.0;
+let pi = 4.0 *. atan(1.0);
 
 let two_pi = 2.0 *. pi;
 

--- a/src/Reprocessing_Constants.rei
+++ b/src/Reprocessing_Constants.rei
@@ -1,42 +1,51 @@
-/** Convenience constant for the color white */
+/*** Convenience constant for the color white */
 let white: Reprocessing_Common.colorT;
 
-/** Convenience constant for the color black */
+
+/*** Convenience constant for the color black */
 let black: Reprocessing_Common.colorT;
 
-/** Convenience constant for the color red */
+
+/*** Convenience constant for the color red */
 let red: Reprocessing_Common.colorT;
 
-/** Convenience constant for the color green */
+
+/*** Convenience constant for the color green */
 let green: Reprocessing_Common.colorT;
 
-/** Convenience constant for the color blue */
+
+/*** Convenience constant for the color blue */
 let blue: Reprocessing_Common.colorT;
 
-/** pi is a mathematical constant with the value 3.1415927. It is the ratio of
-  * the circumference of a circle to its diameter. It is useful in combination
-  * with the trigonometric functions `sin` and `cos`.
-*/
+
+/*** pi is a mathematical constant with the value 3.1415927. It is the ratio of
+   * the circumference of a circle to its diameter. It is useful in combination
+   * with the trigonometric functions `sin` and `cos`.
+ */
 let pi: float;
 
-/** half_pi is a mathematical constant with the value 1.5707964. It is half
-  * the ratio of the circumference of a circle to its diameter
-*/
+
+/*** half_pi is a mathematical constant with the value 1.5707964. It is half
+   * the ratio of the circumference of a circle to its diameter
+ */
 let half_pi: float;
 
-/** quarter_pi is a mathematical constant with the value 0.7853982. It is one
-  * quarter the ratio of the circumference of a circle to its diameter.
-*/
+
+/*** quarter_pi is a mathematical constant with the value 0.7853982. It is one
+   * quarter the ratio of the circumference of a circle to its diameter.
+ */
 let quarter_pi: float;
 
-/** two_pi is a mathematical constant with the value 6.2831855. It is twice the
-  * ratio of the circumference of a circle to its diameter.
-*/
+
+/*** two_pi is a mathematical constant with the value 6.2831855. It is twice the
+   * ratio of the circumference of a circle to its diameter.
+ */
 let two_pi: float;
 
-/** tau is a mathematical constant with the value 6.2831855. It is the circle
-  * constant relating the circumference of a circle to its linear dimension, the
-  * ratio of the circumference of a circle to its radius. It has the same value
-  * as two_pi.
-*/
+
+/*** tau is a mathematical constant with the value 6.2831855. It is the circle
+   * constant relating the circumference of a circle to its linear dimension, the
+   * ratio of the circumference of a circle to its radius. It has the same value
+   * as two_pi.
+ */
 let tau: float;

--- a/src/Reprocessing_Draw.re
+++ b/src/Reprocessing_Draw.re
@@ -8,368 +8,492 @@ module Env = Reprocessing_Env;
 
 module Font = Reprocessing_Font.Font;
 
-let translate ::x ::y env => Matrix.(matmatmul env.matrix (createTranslation x y));
+let translate = (~x, ~y, env) => Matrix.(matmatmul(env.matrix, createTranslation(x, y)));
 
-let rotate theta env => Matrix.(matmatmul env.matrix (createRotation theta));
+let rotate = (theta, env) => Matrix.(matmatmul(env.matrix, createRotation(theta)));
 
-let scale ::x ::y env => Matrix.(matmatmul env.matrix (createScaling x y));
+let scale = (~x, ~y, env) => Matrix.(matmatmul(env.matrix, createScaling(x, y)));
 
-let shear ::x ::y env => Matrix.(matmatmul env.matrix (createShearing x y));
+let shear = (~x, ~y, env) => Matrix.(matmatmul(env.matrix, createShearing(x, y)));
 
-let fill color (env: glEnv) => env.style = {...env.style, fillColor: Some color};
+let fill = (color, env: glEnv) => env.style = {...env.style, fillColor: Some(color)};
 
-let noFill (env: glEnv) => env.style = {...env.style, fillColor: None};
+let noFill = (env: glEnv) => env.style = {...env.style, fillColor: None};
 
-let stroke color env => env.style = {...env.style, strokeColor: Some color};
+let stroke = (color, env) => env.style = {...env.style, strokeColor: Some(color)};
 
-let noStroke env => env.style = {...env.style, strokeColor: None};
+let noStroke = (env) => env.style = {...env.style, strokeColor: None};
 
-let strokeWeight weight env => env.style = {...env.style, strokeWeight: weight};
+let strokeWeight = (weight, env) => env.style = {...env.style, strokeWeight: weight};
 
-let strokeCap cap env => env.style = {...env.style, strokeCap: cap};
+let strokeCap = (cap, env) => env.style = {...env.style, strokeCap: cap};
 
-let pushStyle env => env.styleStack = [env.style, ...env.styleStack];
+let pushStyle = (env) => env.styleStack = [env.style, ...env.styleStack];
 
-let popStyle env =>
+let popStyle = (env) =>
   switch env.styleStack {
   /* Matches Processing error message */
-  | [] => failwith "Too many `popStyle` without enough `pushStyle`."
+  | [] => failwith("Too many `popStyle` without enough `pushStyle`.")
   | [hd, ...tl] =>
     env.style = hd;
     env.styleStack = tl
   };
 
-let pushMatrix env => {
-  let copy = Matrix.createIdentity ();
-  Matrix.copyInto src::env.matrix dst::copy;
+let pushMatrix = (env) => {
+  let copy = Matrix.createIdentity();
+  Matrix.copyInto(~src=env.matrix, ~dst=copy);
   env.matrixStack = [copy, ...env.matrixStack]
 };
 
-let popMatrix env =>
+let popMatrix = (env) =>
   switch env.matrixStack {
-  | [] => failwith "Too many `popMatrix` without enough `pushMatrix`."
+  | [] => failwith("Too many `popMatrix` without enough `pushMatrix`.")
   | [hd, ...tl] =>
     env.matrix = hd;
     env.matrixStack = tl
   };
 
-let loadImage ::filename ::isPixel=false env =>
-  Internal.loadImage env filename isPixel;
+let loadImage = (~filename, ~isPixel=false, env) => Internal.loadImage(env, filename, isPixel);
 
-let subImage
-    img
-    pos::(x, y)
-    ::width
-    ::height
-    texPos::(subx, suby)
-    texWidth::subw
-    texHeight::subh
-    env =>
-  switch !img {
-  | None => print_endline "image not ready yet, just doing nothing :D"
-  | Some i => Internal.drawImageWithMatrix i ::x ::y ::width ::height ::subx ::suby ::subw ::subh env
+let subImage =
+    (
+      img,
+      ~pos as (x, y),
+      ~width,
+      ~height,
+      ~texPos as (subx, suby),
+      ~texWidth as subw,
+      ~texHeight as subh,
+      env
+    ) =>
+  switch img^ {
+  | None => print_endline("image not ready yet, just doing nothing :D")
+  | Some(i) =>
+    Internal.drawImageWithMatrix(i, ~x, ~y, ~width, ~height, ~subx, ~suby, ~subw, ~subh, env)
   };
 
-let image img pos::(x, y) ::width=? ::height=? (env: glEnv) =>
-  switch !img {
-  | None => print_endline "image not ready yet, just doing nothing :D"
-  | Some ({width: imgw, height: imgh} as img) =>
+let image = (img, ~pos as (x, y), ~width=?, ~height=?, env: glEnv) =>
+  switch img^ {
+  | None => print_endline("image not ready yet, just doing nothing :D")
+  | Some({width: imgw, height: imgh} as img) =>
     switch (width, imgw, height, imgh) {
     | (None, w, None, h)
-    | (None, w, Some h, _)
-    | (Some w, _, None, h)
-    | (Some w, _, Some h, _) =>
-      Internal.drawImageWithMatrix img ::x ::y width::w height::h subx::0 suby::0 subw::imgw subh::imgh env
+    | (None, w, Some(h), _)
+    | (Some(w), _, None, h)
+    | (Some(w), _, Some(h), _) =>
+      Internal.drawImageWithMatrix(
+        img,
+        ~x,
+        ~y,
+        ~width=w,
+        ~height=h,
+        ~subx=0,
+        ~suby=0,
+        ~subw=imgw,
+        ~subh=imgh,
+        env
+      )
     }
   };
 
-let linef ::p1 ::p2 (env: glEnv) =>
+let linef = (~p1, ~p2, env: glEnv) =>
   switch env.style.strokeColor {
   | None => () /* don't draw stroke */
-  | Some color =>
-    let transform = Matrix.matptmul env.matrix;
-    let width = float_of_int env.style.strokeWeight;
+  | Some(color) =>
+    let transform = Matrix.matptmul(env.matrix);
+    let width = float_of_int(env.style.strokeWeight);
     let radius = width /. 2.;
     let project = env.style.strokeCap == Project;
-    Internal.drawLine p1::(transform p1) p2::(transform p2) ::color ::width ::project env;
+    Internal.drawLine(~p1=transform(p1), ~p2=transform(p2), ~color, ~width, ~project, env);
     if (env.style.strokeCap == Round) {
-      Internal.drawEllipse env p1 radius radius env.matrix color;
-      Internal.drawEllipse env p2 radius radius env.matrix color
+      Internal.drawEllipse(env, p1, radius, radius, env.matrix, color);
+      Internal.drawEllipse(env, p2, radius, radius, env.matrix, color)
     }
   };
 
-let line p1::(x1, y1) p2::(x2, y2) (env: glEnv) =>
-  linef p1::(float_of_int x1, float_of_int y1) p2::(float_of_int x2, float_of_int y2) env;
+let line = (~p1 as (x1, y1), ~p2 as (x2, y2), env: glEnv) =>
+  linef(~p1=(float_of_int(x1), float_of_int(y1)), ~p2=(float_of_int(x2), float_of_int(y2)), env);
 
-let ellipsef ::center ::radx ::rady (env: glEnv) => {
+let ellipsef = (~center, ~radx, ~rady, env: glEnv) => {
   switch env.style.fillColor {
   | None => () /* Don't draw fill */
-  | Some fill => Internal.drawEllipse env center radx rady env.matrix fill
+  | Some(fill) => Internal.drawEllipse(env, center, radx, rady, env.matrix, fill)
   };
   switch env.style.strokeColor {
   | None => () /* Don't draw stroke */
-  | Some stroke =>
-    Internal.drawArcStroke
-      env
-      center
-      radx
-      rady
-      0.
-      Reprocessing_Constants.tau
-      false
-      false
-      env.matrix
-      stroke
+  | Some(stroke) =>
+    Internal.drawArcStroke(
+      env,
+      center,
+      radx,
+      rady,
+      0.,
+      Reprocessing_Constants.tau,
+      false,
+      false,
+      env.matrix,
+      stroke,
       env.style.strokeWeight
+    )
   }
 };
 
-let ellipse center::(cx, cy) ::radx ::rady (env: glEnv) =>
-  ellipsef
-    center::(float_of_int cx, float_of_int cy)
-    radx::(float_of_int radx)
-    rady::(float_of_int rady)
-    env;
+let ellipse = (~center as (cx, cy), ~radx, ~rady, env: glEnv) =>
+  ellipsef(
+    ~center=(float_of_int(cx), float_of_int(cy)),
+    ~radx=float_of_int(radx),
+    ~rady=float_of_int(rady),
+    env
+  );
 
-let quadf ::p1 ::p2 ::p3 ::p4 (env: glEnv) => {
-  let transform = Matrix.matptmul env.matrix;
-  let (p1, p2, p3, p4) = (transform p1, transform p2, transform p3, transform p4);
+let quadf = (~p1, ~p2, ~p3, ~p4, env: glEnv) => {
+  let transform = Matrix.matptmul(env.matrix);
+  let (p1, p2, p3, p4) = (transform(p1), transform(p2), transform(p3), transform(p4));
   switch env.style.fillColor {
   | None => () /* Don't draw fill */
-  | Some fill =>
-    Internal.addRectToGlobalBatch
-      env topLeft::p1 topRight::p2 bottomRight::p3 bottomLeft::p4 color::fill
+  | Some(fill) =>
+    Internal.addRectToGlobalBatch(
+      env,
+      ~topLeft=p1,
+      ~topRight=p2,
+      ~bottomRight=p3,
+      ~bottomLeft=p4,
+      ~color=fill
+    )
   };
   switch env.style.strokeColor {
   | None => () /* don't draw stroke */
-  | Some color =>
-    let width = float_of_int env.style.strokeWeight;
+  | Some(color) =>
+    let width = float_of_int(env.style.strokeWeight);
     let project = false;
-    Internal.drawLine ::p1 ::p2 ::color ::width ::project env;
-    Internal.drawLine p1::p2 p2::p3 ::color ::width ::project env;
-    Internal.drawLine p1::p3 p2::p4 ::color ::width ::project env;
-    Internal.drawLine ::p1 p2::p4 ::color ::width ::project env;
-    let r = float_of_int env.style.strokeWeight /. 2.;
+    Internal.drawLine(~p1, ~p2, ~color, ~width, ~project, env);
+    Internal.drawLine(~p1=p2, ~p2=p3, ~color, ~width, ~project, env);
+    Internal.drawLine(~p1=p3, ~p2=p4, ~color, ~width, ~project, env);
+    Internal.drawLine(~p1, ~p2=p4, ~color, ~width, ~project, env);
+    let r = float_of_int(env.style.strokeWeight) /. 2.;
     let m = Matrix.identity;
-    Internal.drawEllipse env p1 r r m color;
-    Internal.drawEllipse env p2 r r m color;
-    Internal.drawEllipse env p3 r r m color;
-    Internal.drawEllipse env p4 r r m color
+    Internal.drawEllipse(env, p1, r, r, m, color);
+    Internal.drawEllipse(env, p2, r, r, m, color);
+    Internal.drawEllipse(env, p3, r, r, m, color);
+    Internal.drawEllipse(env, p4, r, r, m, color)
   }
 };
 
-let quad p1::(x1, y1) p2::(x2, y2) p3::(x3, y3) p4::(x4, y4) (env: glEnv) =>
-  quadf
-    p1::(float_of_int x1, float_of_int y1)
-    p2::(float_of_int x2, float_of_int y2)
-    p3::(float_of_int x3, float_of_int y3)
-    p4::(float_of_int x4, float_of_int y4)
-    env;
-
-let rectf pos::(x, y) ::width ::height (env: glEnv) =>
-  quadf p1::(x, y) p2::(x +. width, y) p3::(x +. width, y +. height) p4::(x, y +. height) env;
-
-let rect pos::(x, y) ::width ::height (env: glEnv) =>
-  rectf
-    pos::(float_of_int x, float_of_int y)
-    width::(float_of_int width)
-    height::(float_of_int height)
-    env;
-
-let bezierPoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) t => (
-  (1. -. t) *\* 3. *. xx1 +. 3. *. (1. -. t) *\* 2. *. t *. xx2 +.
-  3. *. (1. -. t) *. t *\* 2. *. xx3 +.
-  t *\* 3. *. xx4,
-  (1. -. t) *\* 3. *. yy1 +. 3. *. (1. -. t) *\* 2. *. t *. yy2 +.
-  3. *. (1. -. t) *. t *\* 2. *. yy3 +.
-  t *\* 3. *. yy4
-);
-
-let bezierTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) t => (
-  (-3.) *. (1. -. t) *\* 2. *. xx1 +. 3. *. (1. -. t) *\* 2. *. xx2 -. 6. *. t *. (1. -. t) *. xx2 -.
-  3. *. t *\* 2. *. xx3 +.
-  6. *. t *. (1. -. t) *. xx3 +.
-  3. *. t *\* 2. *. xx4,
-  (-3.) *. (1. -. t) *\* 2. *. yy1 +. 3. *. (1. -. t) *\* 2. *. yy2 -. 6. *. t *. (1. -. t) *. yy2 -.
-  3. *. t *\* 2. *. yy3 +.
-  6. *. t *. (1. -. t) *. yy3 +.
-  3. *. t *\* 2. *. yy4
-);
-
-let bezier p1::(xx1, yy1) p2::(xx2, yy2) p3::(xx3, yy3) p4::(xx4, yy4) (env: glEnv) =>
-  /* @speed this thing can reuse points*/
-  for i in 0 to 19 {
-    let (x1, y1) =
-      bezierPoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int i /. 20.0);
-    let (x2, y2) =
-      bezierPoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int (i + 1) /. 20.0);
-    let (tangent_x1, tangent_y1) =
-      bezierTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int i /. 20.0);
-    let (tangent_x2, tangent_y2) =
-      bezierTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int (i + 1) /. 20.0);
-    let a1 = atan2 tangent_y1 tangent_x1 -. Reprocessing_Constants.half_pi;
-    let a2 = atan2 tangent_y2 tangent_x2 -. Reprocessing_Constants.half_pi;
-    quadf
-      (
-        x1 +. cos a1 *. float_of_int env.style.strokeWeight /. 2.,
-        y1 +. sin a1 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x1 -. cos a1 *. float_of_int env.style.strokeWeight /. 2.,
-        y1 -. sin a1 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x2 -. cos a2 *. float_of_int env.style.strokeWeight /. 2.,
-        y2 -. sin a2 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x2 +. cos a2 *. float_of_int env.style.strokeWeight /. 2.,
-        y2 +. sin a2 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      env
-  };
-
-let curvePoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) t => {
-  let mx0 = (1. -. 0.5) *. (xx3 -. xx1); /* @feature tightness will be defined as the 0 here */
-  let my0 = (1. -. 0.5) *. (yy3 -. yy1);
-  let mx1 = (1. -. 0.5) *. (xx4 -. xx2);
-  let my1 = (1. -. 0.5) *. (yy4 -. yy2);
-  (
-    (2. *. t *\* 3. -. 3. *. t *\* 2. +. 1.) *. xx2 +. (t *\* 3. -. 2. *. t *\* 2. +. t) *. mx0 +.
-    ((-2.) *. t *\* 3. +. 3. *. t *\* 2.) *. xx3 +.
-    (t *\* 3. -. t *\* 2.) *. mx1,
-    (2. *. t *\* 3. -. 3. *. t *\* 2. +. 1.) *. yy2 +. (t *\* 3. -. 2. *. t *\* 2. +. t) *. my0 +.
-    ((-2.) *. t *\* 3. +. 3. *. t *\* 2.) *. yy3 +.
-    (t *\* 3. -. t *\* 2.) *. my1
-  )
-};
-
-let curveTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) t => {
-  let mx0 = (1. -. 0.5) *. (xx3 -. xx1); /* @feature tightness will be defined as the 0 here */
-  let my0 = (1. -. 0.5) *. (yy3 -. yy1);
-  let mx1 = (1. -. 0.5) *. (xx4 -. xx2);
-  let my1 = (1. -. 0.5) *. (yy4 -. yy2);
-  (
-    (6. *. t *\* 2. -. 6. *. t) *. xx2 +. (3. *. t *\* 2. -. 4. *. t +. 1.) *. mx0 +.
-    ((-6.) *. t *\* 2. +. 6. *. t) *. xx3 +.
-    (3. *. t *\* 2. -. 2. *. t) *. mx1,
-    (6. *. t *\* 2. -. 6. *. t) *. yy2 +. (3. *. t *\* 2. -. 4. *. t +. 1.) *. my0 +.
-    ((-6.) *. t *\* 2. +. 6. *. t) *. yy3 +.
-    (3. *. t *\* 2. -. 2. *. t) *. my1
-  )
-};
-
-let curve (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (env: glEnv) =>
-  for i in 0 to 19 {
-    let (x1, y1) = curvePoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int i /. 20.0);
-    let (x2, y2) =
-      curvePoint (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int (i + 1) /. 20.0);
-    let (tangent_x1, tangent_y1) =
-      curveTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int i /. 20.0);
-    let (tangent_x2, tangent_y2) =
-      curveTangent (xx1, yy1) (xx2, yy2) (xx3, yy3) (xx4, yy4) (float_of_int (i + 1) /. 20.0);
-    let a1 = atan2 tangent_y1 tangent_x1 -. Reprocessing_Constants.half_pi;
-    let a2 = atan2 tangent_y2 tangent_x2 -. Reprocessing_Constants.half_pi;
-    quadf
-      (
-        x1 +. cos a1 *. float_of_int env.style.strokeWeight /. 2.,
-        y1 +. sin a1 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x1 -. cos a1 *. float_of_int env.style.strokeWeight /. 2.,
-        y1 -. sin a1 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x2 -. cos a2 *. float_of_int env.style.strokeWeight /. 2.,
-        y2 -. sin a2 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      (
-        x2 +. cos a2 *. float_of_int env.style.strokeWeight /. 2.,
-        y2 +. sin a2 *. float_of_int env.style.strokeWeight /. 2.
-      )
-      env
-  };
-
-let pixelf pos::(x, y) ::color (env: glEnv) => {
-  let w = float_of_int env.style.strokeWeight;
-  Internal.addRectToGlobalBatch
+let quad = (~p1 as (x1, y1), ~p2 as (x2, y2), ~p3 as (x3, y3), ~p4 as (x4, y4), env: glEnv) =>
+  quadf(
+    ~p1=(float_of_int(x1), float_of_int(y1)),
+    ~p2=(float_of_int(x2), float_of_int(y2)),
+    ~p3=(float_of_int(x3), float_of_int(y3)),
+    ~p4=(float_of_int(x4), float_of_int(y4)),
     env
-    bottomRight::(x +. w, y +. w)
-    bottomLeft::(x, y +. w)
-    topRight::(x +. w, y)
-    topLeft::(x, y)
-    ::color
+  );
+
+let rectf = (~pos as (x, y), ~width, ~height, env: glEnv) =>
+  quadf(~p1=(x, y), ~p2=(x +. width, y), ~p3=(x +. width, y +. height), ~p4=(x, y +. height), env);
+
+let rect = (~pos as (x, y), ~width, ~height, env: glEnv) =>
+  rectf(
+    ~pos=(float_of_int(x), float_of_int(y)),
+    ~width=float_of_int(width),
+    ~height=float_of_int(height),
+    env
+  );
+
+let bezierPoint = ((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), t) => (
+  (1. -. t)
+  ** 3.
+  *. xx1
+  +. 3.
+  *. ((1. -. t) ** 2.)
+  *. t
+  *. xx2
+  +. 3.
+  *. (1. -. t)
+  *. (t ** 2.)
+  *. xx3
+  +. t
+  ** 3.
+  *. xx4,
+  (1. -. t)
+  ** 3.
+  *. yy1
+  +. 3.
+  *. ((1. -. t) ** 2.)
+  *. t
+  *. yy2
+  +. 3.
+  *. (1. -. t)
+  *. (t ** 2.)
+  *. yy3
+  +. t
+  ** 3.
+  *. yy4
+);
+
+let bezierTangent = ((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), t) => (
+  (-3.)
+  *. ((1. -. t) ** 2.)
+  *. xx1
+  +. 3.
+  *. ((1. -. t) ** 2.)
+  *. xx2
+  -. 6.
+  *. t
+  *. (1. -. t)
+  *. xx2
+  -. 3.
+  *. (t ** 2.)
+  *. xx3
+  +. 6.
+  *. t
+  *. (1. -. t)
+  *. xx3
+  +. 3.
+  *. (t ** 2.)
+  *. xx4,
+  (-3.)
+  *. ((1. -. t) ** 2.)
+  *. yy1
+  +. 3.
+  *. ((1. -. t) ** 2.)
+  *. yy2
+  -. 6.
+  *. t
+  *. (1. -. t)
+  *. yy2
+  -. 3.
+  *. (t ** 2.)
+  *. yy3
+  +. 6.
+  *. t
+  *. (1. -. t)
+  *. yy3
+  +. 3.
+  *. (t ** 2.)
+  *. yy4
+);
+
+let bezier =
+    (~p1 as (xx1, yy1), ~p2 as (xx2, yy2), ~p3 as (xx3, yy3), ~p4 as (xx4, yy4), env: glEnv) =>
+  /* @speed this thing can reuse points*/
+  for (i in 0 to 19) {
+    let (x1, y1) =
+      bezierPoint((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i) /. 20.0);
+    let (x2, y2) =
+      bezierPoint((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i + 1) /. 20.0);
+    let (tangent_x1, tangent_y1) =
+      bezierTangent((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i) /. 20.0);
+    let (tangent_x2, tangent_y2) =
+      bezierTangent((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i + 1) /. 20.0);
+    let a1 = atan2(tangent_y1, tangent_x1) -. Reprocessing_Constants.half_pi;
+    let a2 = atan2(tangent_y2, tangent_x2) -. Reprocessing_Constants.half_pi;
+    quadf(
+      (
+        x1 +. cos(a1) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y1 +. sin(a1) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x1 -. cos(a1) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y1 -. sin(a1) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x2 -. cos(a2) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y2 -. sin(a2) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x2 +. cos(a2) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y2 +. sin(a2) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      env
+    )
+  };
+
+let curvePoint = ((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), t) => {
+  let mx0 = (1. -. 0.5) *. (xx3 -. xx1); /* @feature tightness will be defined as the 0 here */
+  let my0 = (1. -. 0.5) *. (yy3 -. yy1);
+  let mx1 = (1. -. 0.5) *. (xx4 -. xx2);
+  let my1 = (1. -. 0.5) *. (yy4 -. yy2);
+  (
+    (2. *. (t ** 3.) -. 3. *. (t ** 2.) +. 1.)
+    *. xx2
+    +. (t ** 3. -. 2. *. (t ** 2.) +. t)
+    *. mx0
+    +. ((-2.) *. (t ** 3.) +. 3. *. (t ** 2.))
+    *. xx3
+    +. (t ** 3. -. t ** 2.)
+    *. mx1,
+    (2. *. (t ** 3.) -. 3. *. (t ** 2.) +. 1.)
+    *. yy2
+    +. (t ** 3. -. 2. *. (t ** 2.) +. t)
+    *. my0
+    +. ((-2.) *. (t ** 3.) +. 3. *. (t ** 2.))
+    *. yy3
+    +. (t ** 3. -. t ** 2.)
+    *. my1
+  )
 };
 
-let pixel pos::(x, y) ::color (env: glEnv) =>
-  pixelf pos::(float_of_int x, float_of_int y) ::color env;
+let curveTangent = ((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), t) => {
+  let mx0 = (1. -. 0.5) *. (xx3 -. xx1); /* @feature tightness will be defined as the 0 here */
+  let my0 = (1. -. 0.5) *. (yy3 -. yy1);
+  let mx1 = (1. -. 0.5) *. (xx4 -. xx2);
+  let my1 = (1. -. 0.5) *. (yy4 -. yy2);
+  (
+    (6. *. (t ** 2.) -. 6. *. t)
+    *. xx2
+    +. (3. *. (t ** 2.) -. 4. *. t +. 1.)
+    *. mx0
+    +. ((-6.) *. (t ** 2.) +. 6. *. t)
+    *. xx3
+    +. (3. *. (t ** 2.) -. 2. *. t)
+    *. mx1,
+    (6. *. (t ** 2.) -. 6. *. t)
+    *. yy2
+    +. (3. *. (t ** 2.) -. 4. *. t +. 1.)
+    *. my0
+    +. ((-6.) *. (t ** 2.) +. 6. *. t)
+    *. yy3
+    +. (3. *. (t ** 2.) -. 2. *. t)
+    *. my1
+  )
+};
 
-let trianglef ::p1 ::p2 ::p3 (env: glEnv) => {
-  let transform = Matrix.matptmul env.matrix;
-  let (p1, p2, p3) = (transform p1, transform p2, transform p3);
+let curve = ((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), env: glEnv) =>
+  for (i in 0 to 19) {
+    let (x1, y1) =
+      curvePoint((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i) /. 20.0);
+    let (x2, y2) =
+      curvePoint((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i + 1) /. 20.0);
+    let (tangent_x1, tangent_y1) =
+      curveTangent((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i) /. 20.0);
+    let (tangent_x2, tangent_y2) =
+      curveTangent((xx1, yy1), (xx2, yy2), (xx3, yy3), (xx4, yy4), float_of_int(i + 1) /. 20.0);
+    let a1 = atan2(tangent_y1, tangent_x1) -. Reprocessing_Constants.half_pi;
+    let a2 = atan2(tangent_y2, tangent_x2) -. Reprocessing_Constants.half_pi;
+    quadf(
+      (
+        x1 +. cos(a1) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y1 +. sin(a1) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x1 -. cos(a1) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y1 -. sin(a1) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x2 -. cos(a2) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y2 -. sin(a2) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      (
+        x2 +. cos(a2) *. float_of_int(env.style.strokeWeight) /. 2.,
+        y2 +. sin(a2) *. float_of_int(env.style.strokeWeight) /. 2.
+      ),
+      env
+    )
+  };
+
+let pixelf = (~pos as (x, y), ~color, env: glEnv) => {
+  let w = float_of_int(env.style.strokeWeight);
+  Internal.addRectToGlobalBatch(
+    env,
+    ~bottomRight=(x +. w, y +. w),
+    ~bottomLeft=(x, y +. w),
+    ~topRight=(x +. w, y),
+    ~topLeft=(x, y),
+    ~color
+  )
+};
+
+let pixel = (~pos as (x, y), ~color, env: glEnv) =>
+  pixelf(~pos=(float_of_int(x), float_of_int(y)), ~color, env);
+
+let trianglef = (~p1, ~p2, ~p3, env: glEnv) => {
+  let transform = Matrix.matptmul(env.matrix);
+  let (p1, p2, p3) = (transform(p1), transform(p2), transform(p3));
   switch env.style.fillColor {
   | None => () /* don't draw fill */
-  | Some color => Internal.drawTriangle env p1 p2 p3 ::color
+  | Some(color) => Internal.drawTriangle(env, p1, p2, p3, ~color)
   };
   switch env.style.strokeColor {
   | None => () /* don't draw stroke */
-  | Some color =>
-    let width = float_of_int env.style.strokeWeight;
+  | Some(color) =>
+    let width = float_of_int(env.style.strokeWeight);
     let project = false;
-    Internal.drawLine ::p1 ::p2 ::color ::width ::project env;
-    Internal.drawLine p1::p2 p2::p3 ::color ::width ::project env;
-    Internal.drawLine ::p1 p2::p3 ::color ::width ::project env;
-    let r = float_of_int env.style.strokeWeight /. 2.;
+    Internal.drawLine(~p1, ~p2, ~color, ~width, ~project, env);
+    Internal.drawLine(~p1=p2, ~p2=p3, ~color, ~width, ~project, env);
+    Internal.drawLine(~p1, ~p2=p3, ~color, ~width, ~project, env);
+    let r = float_of_int(env.style.strokeWeight) /. 2.;
     let m = Matrix.identity;
-    Internal.drawEllipse env p1 r r m color;
-    Internal.drawEllipse env p2 r r m color;
-    Internal.drawEllipse env p3 r r m color
+    Internal.drawEllipse(env, p1, r, r, m, color);
+    Internal.drawEllipse(env, p2, r, r, m, color);
+    Internal.drawEllipse(env, p3, r, r, m, color)
   }
 };
 
-let triangle p1::(x1, y1) p2::(x2, y2) p3::(x3, y3) (env: glEnv) =>
-  trianglef
-    p1::(float_of_int x1, float_of_int y1)
-    p2::(float_of_int x2, float_of_int y2)
-    p3::(float_of_int x3, float_of_int y3)
-    env;
+let triangle = (~p1 as (x1, y1), ~p2 as (x2, y2), ~p3 as (x3, y3), env: glEnv) =>
+  trianglef(
+    ~p1=(float_of_int(x1), float_of_int(y1)),
+    ~p2=(float_of_int(x2), float_of_int(y2)),
+    ~p3=(float_of_int(x3), float_of_int(y3)),
+    env
+  );
 
-let arcf ::center ::radx ::rady ::start ::stop ::isOpen ::isPie (env: glEnv) => {
+let arcf = (~center, ~radx, ~rady, ~start, ~stop, ~isOpen, ~isPie, env: glEnv) => {
   switch env.style.fillColor {
   | None => () /* don't draw fill */
-  | Some color => Internal.drawArc env center radx rady start stop isPie env.matrix color
+  | Some(color) => Internal.drawArc(env, center, radx, rady, start, stop, isPie, env.matrix, color)
   };
   switch env.style.strokeColor {
   | None => () /* don't draw stroke */
-  | Some stroke =>
-    Internal.drawArcStroke
-      env center radx rady start stop isOpen isPie env.matrix stroke env.style.strokeWeight
+  | Some(stroke) =>
+    Internal.drawArcStroke(
+      env,
+      center,
+      radx,
+      rady,
+      start,
+      stop,
+      isOpen,
+      isPie,
+      env.matrix,
+      stroke,
+      env.style.strokeWeight
+    )
   }
 };
 
-let arc center::(cx, cy) ::radx ::rady ::start ::stop ::isOpen ::isPie (env: glEnv) =>
-  arcf
-    center::(float_of_int cx, float_of_int cy)
-    radx::(float_of_int radx)
-    rady::(float_of_int rady)
-    ::start
-    ::stop
-    ::isOpen
-    ::isPie
-    env;
+let arc = (~center as (cx, cy), ~radx, ~rady, ~start, ~stop, ~isOpen, ~isPie, env: glEnv) =>
+  arcf(
+    ~center=(float_of_int(cx), float_of_int(cy)),
+    ~radx=float_of_int(radx),
+    ~rady=float_of_int(rady),
+    ~start,
+    ~stop,
+    ~isOpen,
+    ~isPie,
+    env
+  );
 
-let loadFont ::filename ::isPixel=false (env: glEnv) => Font.parseFontFormat env filename isPixel;
+let loadFont = (~filename, ~isPixel=false, env: glEnv) =>
+  Font.parseFontFormat(env, filename, isPixel);
 
-let text ::font ::body pos::(x, y) (env: glEnv) => Font.drawString env font body x y;
+let text = (~font, ~body, ~pos as (x, y), env: glEnv) => Font.drawString(env, font, body, x, y);
 
-let clear env =>
-  Reasongl.Gl.clear
-    context::env.gl mask::(Constants.color_buffer_bit lor Constants.depth_buffer_bit);
+let clear = (env) =>
+  Reasongl.Gl.clear(
+    ~context=env.gl,
+    ~mask=Constants.color_buffer_bit lor Constants.depth_buffer_bit
+  );
 
-let background color (env: glEnv) => {
-  clear env;
-  let w = float_of_int (Env.width env);
-  let h = float_of_int (Env.height env);
-  Internal.addRectToGlobalBatch
-    env bottomRight::(w, h) bottomLeft::(0., h) topRight::(w, 0.) topLeft::(0., 0.) ::color
+let background = (color, env: glEnv) => {
+  clear(env);
+  let w = float_of_int(Env.width(env));
+  let h = float_of_int(Env.height(env));
+  Internal.addRectToGlobalBatch(
+    env,
+    ~bottomRight=(w, h),
+    ~bottomLeft=(0., h),
+    ~topRight=(w, 0.),
+    ~topLeft=(0., 0.),
+    ~color
+  )
 };

--- a/src/Reprocessing_Draw.rei
+++ b/src/Reprocessing_Draw.rei
@@ -1,4 +1,4 @@
-/** Specifies an amount to displace objects within the display window.
+/*** Specifies an amount to displace objects within the display window.
    * The dx parameter specifies left/right translation, the dy parameter
    * specifies up/down translation.
    *
@@ -10,10 +10,10 @@
    * when the loop begins again. This function can be further controlled
    * by using `pushMatrix` and `popMatrix`.
  */
-let translate: x::float => y::float => Reprocessing_Types.Types.glEnvT => unit;
+let translate: (~x: float, ~y: float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Rotates the amount specified by the angle parameter. Angles must be
+/*** Rotates the amount specified by the angle parameter. Angles must be
  * specified in radians (values from 0 to two_pi), or they can be converted
  * from degrees to radians with the `radians` function.
 
@@ -30,61 +30,56 @@ let translate: x::float => y::float => Reprocessing_Types.Types.glEnvT => unit;
  * rotation matrix. This function can be further controlled by `pushMatrix`
  * and `popMatrix`.
  */
-let rotate: float => Reprocessing_Types.Types.glEnvT => unit;
+let rotate: (float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** The scale() function increases or decreases the size of a shape by expanding
+/*** The scale() function increases or decreases the size of a shape by expanding
  * and contracting vertices.
  */
-let scale: x::float => y::float => Reprocessing_Types.Types.glEnvT => unit;
+let scale: (~x: float, ~y: float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** The shear() function shears the matrix along the axes the amount
+/*** The shear() function shears the matrix along the axes the amount
  * specified by the angle parameters. Angles should be specified in radians
  * (values from 0 to PI*2) or converted to radians with the Utils.radians()
  * function.
  */
-let shear: x::float => y::float => Reprocessing_Types.Types.glEnvT => unit;
+let shear: (~x: float, ~y: float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Sets the color used to fill shapes.*/
-let fill:
-  Reprocessing_Types.Types.colorT => Reprocessing_Types.Types.glEnvT => unit;
+/*** Sets the color used to fill shapes.*/
+let fill: (Reprocessing_Types.Types.colorT, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Disables filling geometry. If both `noStroke` and `noFill` are called,
+/*** Disables filling geometry. If both `noStroke` and `noFill` are called,
    * nothing will be drawn to the screen.
  */
 let noFill: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** Sets the color used to draw lines and borders around shapes. */
-let stroke:
-  Reprocessing_Types.Types.colorT => Reprocessing_Types.Types.glEnvT => unit;
+/*** Sets the color used to draw lines and borders around shapes. */
+let stroke: (Reprocessing_Types.Types.colorT, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Disables drawing the stroke (outline). If both noStroke() and noFill()
+/*** Disables drawing the stroke (outline). If both noStroke() and noFill()
    * are called, nothing will be drawn to the screen.
  */
 let noStroke: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** Sets the width of the stroke used for lines, points, and the border around
+/*** Sets the width of the stroke used for lines, points, and the border around
    * shapes. All widths are set in units of pixels.
  */
-let strokeWeight: int => Reprocessing_Types.Types.glEnvT => unit;
+let strokeWeight: (int, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Sets the style for rendering line endings. These ends are either squared,
+/*** Sets the style for rendering line endings. These ends are either squared,
   * extended, or rounded.
  */
-let strokeCap:
-  Reprocessing_Types.Types.strokeCapT =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+let strokeCap: (Reprocessing_Types.Types.strokeCapT, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** The `pushStyle` function saves the current style settings and `popStyle`
+/*** The `pushStyle` function saves the current style settings and `popStyle`
    * restores the prior settings. Note that these functions are always used
    * together. They allow you to change the style settings and later return to
    * what you had. When a new style is started with `pushStyle`, it builds on the
@@ -97,7 +92,7 @@ let strokeCap:
 let pushStyle: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** The `pushStyle` function saves the current style settings and
+/*** The `pushStyle` function saves the current style settings and
    * `popStyle` restores the prior settings; these functions are always used
    * together. They allow you to change the style settings and later return to
    * what you had. When a new style is started with `pushStyle`, it builds on the
@@ -110,7 +105,7 @@ let pushStyle: Reprocessing_Types.Types.glEnvT => unit;
 let popStyle: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** Pushes the current transformation matrix onto the matrix stack. Understanding pushMatrix() and popMatrix()
+/*** Pushes the current transformation matrix onto the matrix stack. Understanding pushMatrix() and popMatrix()
   * requires understanding the concept of a matrix stack. The pushMatrix() function saves the current coordinate
   * system to the stack and popMatrix() restores the prior coordinate system. pushMatrix() and popMatrix() are
   * used in conjuction with the other transformation methods and may be embedded to control the scope of
@@ -119,7 +114,7 @@ let popStyle: Reprocessing_Types.Types.glEnvT => unit;
 let pushMatrix: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires
+/*** Pops the current transformation matrix off the matrix stack. Understanding pushing and popping requires
   * understanding the concept of a matrix stack. The pushMatrix() function saves the current coordinate system to
   * the stack and popMatrix() restores the prior coordinate system. pushMatrix() and popMatrix() are used in
   * conjuction with the other transformation methods and may be embedded to control the scope of the transformations.
@@ -127,7 +122,7 @@ let pushMatrix: Reprocessing_Types.Types.glEnvT => unit;
 let popMatrix: Reprocessing_Types.Types.glEnvT => unit;
 
 
-/** Loads an image and returns a handle to it. This will lazily load and
+/*** Loads an image and returns a handle to it. This will lazily load and
    * attempting to draw an image that has not finished loading will result
    * in nothing being drawn.
    * In general, all images should be loaded in `setup` to preload them at
@@ -137,26 +132,27 @@ let popMatrix: Reprocessing_Types.Types.glEnvT => unit;
    * pixelated)
  */
 let loadImage:
-  filename::string =>
-  isPixel::bool? =>
-  Reprocessing_Types.Types.glEnvT =>
+  (~filename: string, ~isPixel: bool=?, Reprocessing_Types.Types.glEnvT) =>
   Reprocessing_Types.Types.imageT;
 
 
-/** The `image` function draws an image to the display window.
+/*** The `image` function draws an image to the display window.
    * The image should be loaded using the `loadImage` function.
    * The image is displayed at its original size unless width and
    * height are optionally specified.
  */
 let image:
-  Reprocessing_Types.Types.imageT =>
-  pos::(int, int) =>
-  width::int? =>
-  height::int? =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    Reprocessing_Types.Types.imageT,
+    ~pos: (int, int),
+    ~width: int=?,
+    ~height: int=?,
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
-/** The `subImage` function draws a section of an image to the
+
+/*** The `subImage` function draws a section of an image to the
    * display window. The image should be loaded using the
    * `loadImage` function. The image is displayed at the size
    * specified by width and height.  texPos, texWidth, and
@@ -167,56 +163,45 @@ let image:
    * drawing strategy.
  */
 let subImage:
-  Reprocessing_Types.Types.imageT =>
-  pos::(int, int) =>
-  width::int =>
-  height::int =>
-  texPos::(int, int) =>
-  texWidth::int =>
-  texHeight::int =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    Reprocessing_Types.Types.imageT,
+    ~pos: (int, int),
+    ~width: int,
+    ~height: int,
+    ~texPos: (int, int),
+    ~texWidth: int,
+    ~texHeight: int,
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Draws a rectangle to the screen. A rectangle is a four-sided shape with
+/*** Draws a rectangle to the screen. A rectangle is a four-sided shape with
    * every angle at ninety degrees.
  */
 let rectf:
-  pos::(float, float) =>
-  width::float =>
-  height::float =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+  (~pos: (float, float), ~width: float, ~height: float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws a rectangle to the screen. A rectangle is a four-sided shape with
+/*** Draws a rectangle to the screen. A rectangle is a four-sided shape with
    * every angle at ninety degrees.
    *
    * This is the same as `rectf`, but converts all its integer arguments to floats
    * as a convenience.
  */
-let rect:
-  pos::(int, int) =>
-  width::int =>
-  height::int =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+let rect: (~pos: (int, int), ~width: int, ~height: int, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws a line (a direct path between two points) to the screen.
+/*** Draws a line (a direct path between two points) to the screen.
    * To color a line, use the `stroke` function. A line cannot be filled,
    * therefore the `fill` function will not affect the color of a line. Lines are
    * drawn with a width of one pixel by default, but this can be changed with
    * the `strokeWeight` function.
  */
-let linef:
-  p1::(float, float) =>
-  p2::(float, float) =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+let linef: (~p1: (float, float), ~p2: (float, float), Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws a line (a direct path between two points) to the screen.
+/*** Draws a line (a direct path between two points) to the screen.
    * To color a line, use the `stroke` function. A line cannot be filled,
    * therefore the `fill` function will not affect the color of a line. Lines are
    * drawn with a width of one pixel by default, but this can be changed with
@@ -225,50 +210,43 @@ let linef:
    * This is the same as `linef`, but converts all its integer arguments to floats
    * as a convenience.
  */
-let line:
-  p1::(int, int) => p2::(int, int) => Reprocessing_Types.Types.glEnvT => unit;
+let line: (~p1: (int, int), ~p2: (int, int), Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws an ellipse (oval) to the screen. An ellipse with equal width and
+/*** Draws an ellipse (oval) to the screen. An ellipse with equal width and
    * height is a circle.
  */
 let ellipsef:
-  center::(float, float) =>
-  radx::float =>
-  rady::float =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+  (~center: (float, float), ~radx: float, ~rady: float, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws an ellipse (oval) to the screen. An ellipse with equal width and
+/*** Draws an ellipse (oval) to the screen. An ellipse with equal width and
    * height is a circle.
    *
    * This is the same as `ellipsef`, but converts all its integer arguments to
    * floats as a convenience.
  */
 let ellipse:
-  center::(int, int) =>
-  radx::int =>
-  rady::int =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+  (~center: (int, int), ~radx: int, ~rady: int, Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/**  A quad is a quadrilateral, a four sided polygon. It is similar to a
+/***  A quad is a quadrilateral, a four sided polygon. It is similar to a
    * rectangle, but the angles between its edges are not constrained to ninety
    * degrees. The parameter p1 sets the first vertex and the subsequest points
    * should proceed clockwise or counter-clockwise around the defined shape.
  */
 let quadf:
-  p1::(float, float) =>
-  p2::(float, float) =>
-  p3::(float, float) =>
-  p4::(float, float) =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~p1: (float, float),
+    ~p2: (float, float),
+    ~p3: (float, float),
+    ~p4: (float, float),
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/**  A quad is a quadrilateral, a four sided polygon. It is similar to a
+/***  A quad is a quadrilateral, a four sided polygon. It is similar to a
    * rectangle, but the angles between its edges are not constrained to ninety
    * degrees. The parameter p1 sets the first vertex and the subsequest points
    * should proceed clockwise or counter-clockwise around the defined shape.
@@ -277,57 +255,57 @@ let quadf:
    * floats as a convenience.
  */
 let quad:
-  p1::(int, int) =>
-  p2::(int, int) =>
-  p3::(int, int) =>
-  p4::(int, int) =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~p1: (int, int),
+    ~p2: (int, int),
+    ~p3: (int, int),
+    ~p4: (int, int),
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Adds a single point with a radius defined by strokeWeight */
+/*** Adds a single point with a radius defined by strokeWeight */
 let pixelf:
-  pos::(float, float) =>
-  color::Reprocessing_Types.Types.colorT =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~pos: (float, float),
+    ~color: Reprocessing_Types.Types.colorT,
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Adds a single point with a radius defined by strokeWeight
+/*** Adds a single point with a radius defined by strokeWeight
    *
    * This is the same as `pixelf`, but converts all its integer arguments to
    * floats as a convenience.
  */
 let pixel:
-  pos::(int, int) =>
-  color::Reprocessing_Types.Types.colorT =>
-  Reprocessing_Types.Types.glEnvT =>
+  (~pos: (int, int), ~color: Reprocessing_Types.Types.colorT, Reprocessing_Types.Types.glEnvT) =>
   unit;
 
 
-/** A triangle is a plane created by connecting three points. */
+/*** A triangle is a plane created by connecting three points. */
 let trianglef:
-  p1::(float, float) =>
-  p2::(float, float) =>
-  p3::(float, float) =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~p1: (float, float),
+    ~p2: (float, float),
+    ~p3: (float, float),
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** A triangle is a plane created by connecting three points.
+/*** A triangle is a plane created by connecting three points.
    *
    * This is the same as `trianglef`, but converts all its integer arguments to
    * floats as a convenience.
  */
 let triangle:
-  p1::(int, int) =>
-  p2::(int, int) =>
-  p3::(int, int) =>
-  Reprocessing_Types.Types.glEnvT =>
-  unit;
+  (~p1: (int, int), ~p2: (int, int), ~p3: (int, int), Reprocessing_Types.Types.glEnvT) => unit;
 
 
-/** Draws a Bezier curve on the screen. These curves are defined by a
+/*** Draws a Bezier curve on the screen. These curves are defined by a
    * series of anchor and control points. The parameter p1 specifies the
    * first anchor point and the last parameter specifies the other anchor
    * point. The middle parameters p2 and p3 specify the control points
@@ -335,15 +313,17 @@ let triangle:
    * by French engineer Pierre Bezier.
  */
 let bezier:
-  p1::(float, float) =>
-  p2::(float, float) =>
-  p3::(float, float) =>
-  p4::(float, float) =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~p1: (float, float),
+    ~p2: (float, float),
+    ~p3: (float, float),
+    ~p4: (float, float),
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Draws an arc to the screen. Arcs are drawn along the outer edge of an
+/*** Draws an arc to the screen. Arcs are drawn along the outer edge of an
    * ellipse defined by the center, radx, and rady parameters. Use the
    * start and stop parameters to specify the angles (in radians) at which
    * to draw the arc. isPie defines whether or not lines should be drawn to
@@ -352,18 +332,20 @@ let bezier:
    * than the arc between start and stop.
  */
 let arcf:
-  center::(float, float) =>
-  radx::float =>
-  rady::float =>
-  start::float =>
-  stop::float =>
-  isOpen::bool =>
-  isPie::bool =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~center: (float, float),
+    ~radx: float,
+    ~rady: float,
+    ~start: float,
+    ~stop: float,
+    ~isOpen: bool,
+    ~isPie: bool,
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Draws an arc to the screen. Arcs are drawn along the outer edge of an
+/*** Draws an arc to the screen. Arcs are drawn along the outer edge of an
    * ellipse defined by the center, radx, and rady parameters. Use the
    * start and stop parameters to specify the angles (in radians) at which
    * to draw the arc. isPie defines whether or not lines should be drawn to
@@ -375,18 +357,20 @@ let arcf:
    * floats as a convenience.
  */
 let arc:
-  center::(int, int) =>
-  radx::int =>
-  rady::int =>
-  start::float =>
-  stop::float =>
-  isOpen::bool =>
-  isPie::bool =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~center: (int, int),
+    ~radx: int,
+    ~rady: int,
+    ~start: float,
+    ~stop: float,
+    ~isOpen: bool,
+    ~isPie: bool,
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
 
-/** Loads a font and returns a handle to it. This will lazily load and
+/*** Loads a font and returns a handle to it. This will lazily load and
    * attempting to draw an font that has not finished loading will result
    * in nothing being drawn.
    * In general, all fonts should be loaded in `setup` to preload them at
@@ -396,31 +380,31 @@ let arc:
    * pixelated)
  */
 let loadFont:
-  filename::string =>
-  isPixel::bool? =>
-  Reprocessing_Types.Types.glEnvT =>
-  Reprocessing_Font.fontT;
+  (~filename: string, ~isPixel: bool=?, Reprocessing_Types.Types.glEnvT) => Reprocessing_Font.fontT;
 
 
-/** Draws text to the screen.
+/*** Draws text to the screen.
    * The font should be loaded using the `loadFont` function.
  */
 let text:
-  font::Reprocessing_Font.fontT =>
-  body::string =>
-  pos::(int, int) =>
-  Reprocessing_Types.Types.glEnvT =>
+  (
+    ~font: Reprocessing_Font.fontT,
+    ~body: string,
+    ~pos: (int, int),
+    Reprocessing_Types.Types.glEnvT
+  ) =>
   unit;
 
-/** Clears the entire screen. Normally, background is used for this purpose,
-  * clear will have different results in web and native. */
+
+/*** Clears the entire screen. Normally, background is used for this purpose,
+ * clear will have different results in web and native. */
 let clear: Reprocessing_Types.Types.glEnvT => unit;
 
-/** The `background` function sets the color used for the background of the
+
+/*** The `background` function sets the color used for the background of the
    * Processing window. The default background is black. This function is
    * typically used within `draw` to clear the display window at the beginning of
    * each frame, but it can be used inside `setup` to set the background on the
    * first frame of animation or if the backgound need only be set once.
  */
-let background:
-  Reprocessing_Types.Types.colorT => Reprocessing_Types.Types.glEnvT => unit;
+let background: (Reprocessing_Types.Types.colorT, Reprocessing_Types.Types.glEnvT) => unit;

--- a/src/Reprocessing_Env.re
+++ b/src/Reprocessing_Env.re
@@ -1,26 +1,26 @@
 open Reprocessing_Common;
 
-let width env => env.size.width;
+let width = (env) => env.size.width;
 
-let height env => env.size.height;
+let height = (env) => env.size.height;
 
-let mouse env => env.mouse.pos;
+let mouse = (env) => env.mouse.pos;
 
-let pmouse env => env.mouse.prevPos;
+let pmouse = (env) => env.mouse.prevPos;
 
-let mousePressed env => env.mouse.pressed;
+let mousePressed = (env) => env.mouse.pressed;
 
-let keyCode env => env.keyboard.keyCode;
+let keyCode = (env) => env.keyboard.keyCode;
 
-let size ::width ::height (env: glEnv) => {
-  Reasongl.Gl.Window.setWindowSize window::env.window ::width ::height;
-  Reprocessing_Internal.resetSize env width height
+let size = (~width, ~height, env: glEnv) => {
+  Reasongl.Gl.Window.setWindowSize(~window=env.window, ~width, ~height);
+  Reprocessing_Internal.resetSize(env, width, height)
 };
 
-let resizeable resizeable (env: glEnv) => env.size.resizeable = resizeable;
+let resizeable = (resizeable, env: glEnv) => env.size.resizeable = resizeable;
 
-let frameRate (env: glEnv) => env.frame.rate;
+let frameRate = (env: glEnv) => env.frame.rate;
 
-let frameCount (env: glEnv) => env.frame.count;
+let frameCount = (env: glEnv) => env.frame.count;
 
-let deltaTime (env: glEnv) => env.frame.deltaTime;
+let deltaTime = (env: glEnv) => env.frame.deltaTime;

--- a/src/Reprocessing_Env.rei
+++ b/src/Reprocessing_Env.rei
@@ -1,13 +1,23 @@
 let width: Reprocessing_Types.Types.glEnvT => int;
+
 let height: Reprocessing_Types.Types.glEnvT => int;
+
 let mouse: Reprocessing_Types.Types.glEnvT => (int, int);
+
 let pmouse: Reprocessing_Types.Types.glEnvT => (int, int);
+
 let mousePressed: Reprocessing_Types.Types.glEnvT => bool;
+
 let keyCode: Reprocessing_Types.Types.glEnvT => Reprocessing_Events.keycodeT;
-let size: width::int => height::int => Reprocessing_Types.Types.glEnvT => unit;
-let resizeable: bool => Reprocessing_Types.Types.glEnvT => unit;
+
+let size: (~width: int, ~height: int, Reprocessing_Types.Types.glEnvT) => unit;
+
+let resizeable: (bool, Reprocessing_Types.Types.glEnvT) => unit;
+
 let frameRate: Reprocessing_Types.Types.glEnvT => int;
+
 let frameCount: Reprocessing_Types.Types.glEnvT => int;
 
-/** Time in seconds since the last frame */
+
+/*** Time in seconds since the last frame */
 let deltaTime: Reprocessing_Types.Types.glEnvT => float;

--- a/src/Reprocessing_Events.re
+++ b/src/Reprocessing_Events.re
@@ -1,5 +1,4 @@
-type buttonStateT =
-  Reasongl.Gl.Events.buttonStateT = | LeftButton | MiddleButton | RightButton;
+type buttonStateT = Reasongl.Gl.Events.buttonStateT = | LeftButton | MiddleButton | RightButton;
 
 type stateT = Reasongl.Gl.Events.stateT = | MouseDown | MouseUp;
 

--- a/src/Reprocessing_Font.re
+++ b/src/Reprocessing_Font.re
@@ -6,22 +6,26 @@ open Reprocessing_Common;
 
 module Font = {
   module IntMap =
-    Map.Make {
-      type t = int;
-      let compare = compare;
-    };
+    Map.Make(
+      {
+        type t = int;
+        let compare = compare;
+      }
+    );
   module IntPairMap =
-    Map.Make {
-      type t = (int, int);
-      let compare (a1, a2) (b1, b2) => {
-        let first = compare a1 b1;
-        if (first != 0) {
-          first
-        } else {
-          compare a2 b2
-        }
-      };
-    };
+    Map.Make(
+      {
+        type t = (int, int);
+        let compare = ((a1, a2), (b1, b2)) => {
+          let first = compare(a1, b1);
+          if (first != 0) {
+            first
+          } else {
+            compare(a2, b2)
+          }
+        };
+      }
+    );
   type charT = {
     x: int,
     y: int,
@@ -32,186 +36,180 @@ module Font = {
     xadvance: int
   };
   type internalType = {
-    chars: IntMap.t charT,
-    kerning: IntPairMap.t int,
+    chars: IntMap.t(charT),
+    kerning: IntPairMap.t(int),
     image: imageT
   };
-  type t = ref (option internalType);
-  let rec parse_num (stream: Stream.t) acc :(Stream.t, int) =>
-    switch (Stream.peekch stream) {
-    | Some ('-' as c)
-    | Some ('0'..'9' as c) =>
-      parse_num (Stream.popch stream) (append_char acc c)
+  type t = ref(option(internalType));
+  let rec parse_num = (stream: Stream.t, acc) : (Stream.t, int) =>
+    switch (Stream.peekch(stream)) {
+    | Some('-' as c)
+    | Some('0'..'9' as c) => parse_num(Stream.popch(stream), append_char(acc, c))
     | _ =>
-      try (stream, int_of_string acc) {
-      | _ => failwith ("Could not parse number [" ^ acc ^ "].")
+      try (stream, int_of_string(acc)) {
+      | _ => failwith("Could not parse number [" ++ (acc ++ "]."))
       }
     };
-  let parse_num stream => parse_num stream "";
-  let rec parse_string (stream: Stream.t) (acc: string) :(Stream.t, string) =>
-    switch (Stream.peekch stream) {
-    | Some '"' => (Stream.popch stream, acc)
-    | Some c => parse_string (Stream.popch stream) (append_char acc c)
-    | None => failwith "Unterminated string."
+  let parse_num = (stream) => parse_num(stream, "");
+  let rec parse_string = (stream: Stream.t, acc: string) : (Stream.t, string) =>
+    switch (Stream.peekch(stream)) {
+    | Some('"') => (Stream.popch(stream), acc)
+    | Some(c) => parse_string(Stream.popch(stream), append_char(acc, c))
+    | None => failwith("Unterminated string.")
     };
-  let parse_string stream => parse_string stream "";
-  let rec pop_line stream =>
-    switch (Stream.peekch stream) {
-    | Some '\n' => Stream.popch stream
-    | Some _ => pop_line (Stream.popch stream)
-    | None => failwith "could not pop line"
+  let parse_string = (stream) => parse_string(stream, "");
+  let rec pop_line = (stream) =>
+    switch (Stream.peekch(stream)) {
+    | Some('\n') => Stream.popch(stream)
+    | Some(_) => pop_line(Stream.popch(stream))
+    | None => failwith("could not pop line")
     };
-  let rec parse_char_fmt stream num map =>
+  let rec parse_char_fmt = (stream, num, map) =>
     if (num < 0) {
       (stream, map)
     } else {
-      let stream = Stream.match stream "char id=";
-      let (stream, char_id) = parse_num stream;
-      let stream = Stream.match stream " x=";
-      let (stream, x) = parse_num stream;
-      let stream = Stream.match stream " y=";
-      let (stream, y) = parse_num stream;
-      let stream = Stream.match stream " width=";
-      let (stream, width) = parse_num stream;
-      let stream = Stream.match stream " height=";
-      let (stream, height) = parse_num stream;
-      let stream = Stream.match stream " xoffset=";
-      let (stream, xoffset) = parse_num stream;
-      let stream = Stream.match stream " yoffset=";
-      let (stream, yoffset) = parse_num stream;
-      let stream = Stream.match stream " xadvance=";
-      let (stream, xadvance) = parse_num stream;
-      let stream = pop_line stream;
-      let new_map =
-        IntMap.add
-          char_id {x, y, width, height, xoffset, yoffset, xadvance} map;
-      parse_char_fmt stream (num - 1) new_map
+      let stream = Stream.switch_(stream, "char id=");
+      let (stream, char_id) = parse_num(stream);
+      let stream = Stream.switch_(stream, " x=");
+      let (stream, x) = parse_num(stream);
+      let stream = Stream.switch_(stream, " y=");
+      let (stream, y) = parse_num(stream);
+      let stream = Stream.switch_(stream, " width=");
+      let (stream, width) = parse_num(stream);
+      let stream = Stream.switch_(stream, " height=");
+      let (stream, height) = parse_num(stream);
+      let stream = Stream.switch_(stream, " xoffset=");
+      let (stream, xoffset) = parse_num(stream);
+      let stream = Stream.switch_(stream, " yoffset=");
+      let (stream, yoffset) = parse_num(stream);
+      let stream = Stream.switch_(stream, " xadvance=");
+      let (stream, xadvance) = parse_num(stream);
+      let stream = pop_line(stream);
+      let new_map = IntMap.add(char_id, {x, y, width, height, xoffset, yoffset, xadvance}, map);
+      parse_char_fmt(stream, num - 1, new_map)
     };
-  let rec parse_kern_fmt stream num map =>
+  let rec parse_kern_fmt = (stream, num, map) =>
     if (num == 0) {
       (stream, map)
     } else {
-      let stream = Stream.match stream "kerning first=";
-      let (stream, first) = parse_num stream;
-      let stream = Stream.match stream " second=";
-      let (stream, second) = parse_num stream;
-      let stream = Stream.match stream " amount=";
-      let (stream, amount) = parse_num stream;
-      let stream = pop_line stream;
-      let new_map = IntPairMap.add (first, second) amount map;
-      parse_kern_fmt stream (num - 1) new_map
+      let stream = Stream.switch_(stream, "kerning first=");
+      let (stream, first) = parse_num(stream);
+      let stream = Stream.switch_(stream, " second=");
+      let (stream, second) = parse_num(stream);
+      let stream = Stream.switch_(stream, " amount=");
+      let (stream, amount) = parse_num(stream);
+      let stream = pop_line(stream);
+      let new_map = IntPairMap.add((first, second), amount, map);
+      parse_kern_fmt(stream, num - 1, new_map)
     };
-  let replaceFilename path filename => {
-    let splitStr = Reprocessing_Common.split path sep::'/';
-    let revLst = List.rev splitStr;
+  let replaceFilename = (path, filename) => {
+    let splitStr = Reprocessing_Common.split(path, ~sep='/');
+    let revLst = List.rev(splitStr);
     let newRevLst =
       switch revLst {
       | [_, ...tl] => [filename, ...tl]
       | [] => []
       };
-    let newLst = List.rev newRevLst;
-    String.concat "/" newLst
+    let newLst = List.rev(newRevLst);
+    String.concat("/", newLst)
   };
-  let parseFontFormat env path isPixel => {
-    let ret = ref None;
-    Gl.File.readFile
-      filename::path
-      cb::(
-        fun str => {
-          let stream = Stream.create (str ^ "\n");
+  let parseFontFormat = (env, path, isPixel) => {
+    let ret = ref(None);
+    Gl.File.readFile(
+      ~filename=path,
+      ~cb=
+        (str) => {
+          let stream = Stream.create(str ++ "\n");
           let stream = stream |> pop_line |> pop_line;
-          let stream = Stream.match stream "page id=0 file=\"";
-          let (stream, filename) = parse_string stream;
-          let stream = pop_line stream;
-          let stream = Stream.match stream "chars count=";
-          let (stream, num_chars) = parse_num stream;
-          let stream = pop_line stream;
-          let (stream, char_map) =
-            parse_char_fmt stream num_chars IntMap.empty;
-          let stream = Stream.match stream "kernings count=";
-          let (stream, num_kerns) = parse_num stream;
-          let stream = pop_line stream;
-          let (_, kern_map) = parse_kern_fmt stream num_kerns IntPairMap.empty;
-          let img_filename = replaceFilename path filename;
+          let stream = Stream.switch_(stream, "page id=0 file=\"");
+          let (stream, filename) = parse_string(stream);
+          let stream = pop_line(stream);
+          let stream = Stream.switch_(stream, "chars count=");
+          let (stream, num_chars) = parse_num(stream);
+          let stream = pop_line(stream);
+          let (stream, char_map) = parse_char_fmt(stream, num_chars, IntMap.empty);
+          let stream = Stream.switch_(stream, "kernings count=");
+          let (stream, num_kerns) = parse_num(stream);
+          let stream = pop_line(stream);
+          let (_, kern_map) = parse_kern_fmt(stream, num_kerns, IntPairMap.empty);
+          let img_filename = replaceFilename(path, filename);
           ret :=
-            Some {
+            Some({
               chars: char_map,
               kerning: kern_map,
-              image: Internal.loadImage env img_filename isPixel
-            }
+              image: Internal.loadImage(env, img_filename, isPixel)
+            })
         }
-      );
+    );
     ret
   };
-  let getChar fnt ch => {
-    let code = Char.code ch;
-    try (IntMap.find code fnt.chars) {
-    | _ =>
-      failwith ("Could not find character " ^ string_of_int code ^ " in font.")
+  let getChar = (fnt, ch) => {
+    let code = Char.code(ch);
+    try (IntMap.find(code, fnt.chars)) {
+    | _ => failwith("Could not find character " ++ (string_of_int(code) ++ " in font."))
     }
   };
-  let drawChar (env: glEnv) fnt image (ch: char) (last: option char) x y => {
-    let c = getChar fnt ch;
+  let drawChar = (env: glEnv, fnt, image, ch: char, last: option(char), x, y) => {
+    let c = getChar(fnt, ch);
     let kernAmount =
       switch last {
-      | Some lastCh =>
-        let first = Char.code lastCh;
-        let second = Char.code ch;
-        try (IntPairMap.find (first, second) fnt.kerning) {
+      | Some(lastCh) =>
+        let first = Char.code(lastCh);
+        let second = Char.code(ch);
+        try (IntPairMap.find((first, second), fnt.kerning)) {
         | _ => 0
         }
       | None => 0
       };
     switch image {
-    | Some img =>
-      Internal.drawImageWithMatrix
-        img
-        x::(x + c.xoffset + kernAmount)
-        y::(y + c.yoffset)
-        width::c.width
-        height::c.height
-        subx::c.x
-        suby::c.y
-        subw::c.width
-        subh::c.height
-        env;
+    | Some(img) =>
+      Internal.drawImageWithMatrix(
+        img,
+        ~x=x + c.xoffset + kernAmount,
+        ~y=y + c.yoffset,
+        ~width=c.width,
+        ~height=c.height,
+        ~subx=c.x,
+        ~suby=c.y,
+        ~subw=c.width,
+        ~subh=c.height,
+        env
+      );
       c.xadvance + kernAmount
     | None => c.xadvance + kernAmount
     }
   };
-  let drawString (env: glEnv) fnt (str: string) x y =>
-    switch !fnt {
+  let drawString = (env: glEnv, fnt, str: string, x, y) =>
+    switch fnt^ {
     | None => ()
-    | Some fnt =>
-      switch !fnt.image {
-      | Some img =>
-        let offset = ref x;
-        let lastChar = ref None;
-        String.iter
-          (
-            fun c => {
-              let advance = drawChar env fnt (Some img) c !lastChar !offset y;
-              offset := !offset + advance;
-              lastChar := Some c
-            }
-          )
+    | Some(fnt) =>
+      switch fnt.image^ {
+      | Some(img) =>
+        let offset = ref(x);
+        let lastChar = ref(None);
+        String.iter(
+          (c) => {
+            let advance = drawChar(env, fnt, Some(img), c, lastChar^, offset^, y);
+            offset := offset^ + advance;
+            lastChar := Some(c)
+          },
           str
-      | None => print_endline "loading font."
+        )
+      | None => print_endline("loading font.")
       }
     };
-  let calcStringWidth env fnt (str: string) => {
-    let offset = ref 0;
-    let lastChar = ref None;
-    String.iter
-      (
-        fun c => {
-          offset := !offset + drawChar env fnt None c !lastChar !offset 0;
-          lastChar := Some c
-        }
-      )
-      str;
-    !offset
+  let calcStringWidth = (env, fnt, str: string) => {
+    let offset = ref(0);
+    let lastChar = ref(None);
+    String.iter(
+      (c) => {
+        offset := offset^ + drawChar(env, fnt, None, c, lastChar^, offset^, 0);
+        lastChar := Some(c)
+      },
+      str
+    );
+    offset^
   };
 };
 
-type fontT = ref (option Font.internalType);
+type fontT = ref(option(Font.internalType));

--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -4,162 +4,187 @@ open Reasongl;
 
 module Matrix = Reprocessing_Matrix;
 
-let getProgram
-    ::context
-    vertexShader::(vertexShaderSource: string)
-    fragmentShader::(fragmentShaderSource: string)
-    :option Gl.programT => {
-  let vertexShader = Gl.createShader ::context RGLConstants.vertex_shader;
-  Gl.shaderSource ::context shader::vertexShader source::vertexShaderSource;
-  Gl.compileShader ::context vertexShader;
+let getProgram =
+    (
+      ~context,
+      ~vertexShader as vertexShaderSource: string,
+      ~fragmentShader as fragmentShaderSource: string
+    )
+    : option(Gl.programT) => {
+  let vertexShader = Gl.createShader(~context, RGLConstants.vertex_shader);
+  Gl.shaderSource(~context, ~shader=vertexShader, ~source=vertexShaderSource);
+  Gl.compileShader(~context, vertexShader);
   let compiledCorrectly =
-    Gl.getShaderParameter
-      ::context shader::vertexShader paramName::Gl.Compile_status
+    Gl.getShaderParameter(
+      ~context,
+      ~shader=vertexShader,
+      ~paramName=Gl.Compile_status
+    )
     == 1;
-  if compiledCorrectly {
+  if (compiledCorrectly) {
     let fragmentShader =
-      Gl.createShader ::context RGLConstants.fragment_shader;
-    Gl.shaderSource
-      ::context shader::fragmentShader source::fragmentShaderSource;
-    Gl.compileShader ::context fragmentShader;
+      Gl.createShader(~context, RGLConstants.fragment_shader);
+    Gl.shaderSource(
+      ~context,
+      ~shader=fragmentShader,
+      ~source=fragmentShaderSource
+    );
+    Gl.compileShader(~context, fragmentShader);
     let compiledCorrectly =
-      Gl.getShaderParameter
-        ::context shader::fragmentShader paramName::Gl.Compile_status
+      Gl.getShaderParameter(
+        ~context,
+        ~shader=fragmentShader,
+        ~paramName=Gl.Compile_status
+      )
       == 1;
-    if compiledCorrectly {
-      let program = Gl.createProgram ::context;
-      Gl.attachShader ::context ::program shader::vertexShader;
-      Gl.deleteShader ::context vertexShader;
-      Gl.attachShader ::context ::program shader::fragmentShader;
-      Gl.deleteShader ::context fragmentShader;
-      Gl.linkProgram ::context program;
+    if (compiledCorrectly) {
+      let program = Gl.createProgram(~context);
+      Gl.attachShader(~context, ~program, ~shader=vertexShader);
+      Gl.deleteShader(~context, vertexShader);
+      Gl.attachShader(~context, ~program, ~shader=fragmentShader);
+      Gl.deleteShader(~context, fragmentShader);
+      Gl.linkProgram(~context, program);
       let linkedCorrectly =
-        Gl.getProgramParameter ::context ::program paramName::Gl.Link_status
+        Gl.getProgramParameter(~context, ~program, ~paramName=Gl.Link_status)
         == 1;
-      if linkedCorrectly {
-        Some program
+      if (linkedCorrectly) {
+        Some(program)
       } else {
-        print_endline
-        @@ "Linking error: "
-        ^ Gl.getProgramInfoLog ::context program;
+        print_endline @@
+        "Linking error: "
+        ++ Gl.getProgramInfoLog(~context, program);
         None
       }
     } else {
-      print_endline
-      @@ "Fragment shader error: "
-      ^ Gl.getShaderInfoLog ::context fragmentShader;
+      print_endline @@
+      "Fragment shader error: "
+      ++ Gl.getShaderInfoLog(~context, fragmentShader);
       None
     }
   } else {
-    print_endline
-    @@ "Vertex shader error: "
-    ^ Gl.getShaderInfoLog ::context vertexShader;
+    print_endline @@
+    "Vertex shader error: "
+    ++ Gl.getShaderInfoLog(~context, vertexShader);
     None
   }
 };
 
-let createCanvas window (height: int) (width: int) :glEnv => {
-  Gl.Window.setWindowSize ::window ::width ::height;
-  let context = Gl.Window.getContext window;
-  Gl.viewport ::context x::(-1) y::(-1) ::width ::height;
-  Gl.clearColor ::context r::0. g::0. b::0. a::1.;
-  Gl.clear
-    ::context
-    mask::(RGLConstants.color_buffer_bit lor RGLConstants.depth_buffer_bit);
+let createCanvas = (window, height: int, width: int) : glEnv => {
+  Gl.Window.setWindowSize(~window, ~width, ~height);
+  let context = Gl.Window.getContext(window);
+  Gl.viewport(~context, ~x=(-1), ~y=(-1), ~width, ~height);
+  Gl.clearColor(~context, ~r=0., ~g=0., ~b=0., ~a=1.);
+  Gl.clear(
+    ~context,
+    ~mask=RGLConstants.color_buffer_bit lor RGLConstants.depth_buffer_bit
+  );
 
-  /** Camera is a simple record containing one matrix used to project a point in 3D onto the screen. **/
-  let camera = {projectionMatrix: Gl.Mat4.create ()};
-  let vertexBuffer = Gl.createBuffer ::context;
-  let elementBuffer = Gl.createBuffer ::context;
+  /*** Camera is a simple record containing one matrix used to project a point in 3D onto the screen. **/
+  let camera = {projectionMatrix: Gl.Mat4.create()};
+  let vertexBuffer = Gl.createBuffer(~context);
+  let elementBuffer = Gl.createBuffer(~context);
   let program =
     switch (
-      getProgram
-        ::context
-        vertexShader::Reprocessing_Shaders.vertexShaderSource
-        fragmentShader::Reprocessing_Shaders.fragmentShaderSource
+      getProgram(
+        ~context,
+        ~vertexShader=Reprocessing_Shaders.vertexShaderSource,
+        ~fragmentShader=Reprocessing_Shaders.fragmentShaderSource
+      )
     ) {
     | None =>
-      failwith "Could not create the program and/or the shaders. Aborting."
-    | Some program => program
+      failwith("Could not create the program and/or the shaders. Aborting.")
+    | Some(program) => program
     };
-  Gl.useProgram ::context program;
+  Gl.useProgram(~context, program);
 
-  /** Get the attribs ahead of time to be used inside the render function **/
+  /*** Get the attribs ahead of time to be used inside the render function **/
   let aVertexPosition =
-    Gl.getAttribLocation ::context ::program name::"aVertexPosition";
-  Gl.enableVertexAttribArray ::context attribute::aVertexPosition;
+    Gl.getAttribLocation(~context, ~program, ~name="aVertexPosition");
+  Gl.enableVertexAttribArray(~context, ~attribute=aVertexPosition);
   let aVertexColor =
-    Gl.getAttribLocation ::context ::program name::"aVertexColor";
-  Gl.enableVertexAttribArray ::context attribute::aVertexColor;
+    Gl.getAttribLocation(~context, ~program, ~name="aVertexColor");
+  Gl.enableVertexAttribArray(~context, ~attribute=aVertexColor);
   let pMatrixUniform =
-    Gl.getUniformLocation ::context ::program name::"uPMatrix";
-  Gl.uniformMatrix4fv
-    ::context location::pMatrixUniform value::camera.projectionMatrix;
+    Gl.getUniformLocation(~context, ~program, ~name="uPMatrix");
+  Gl.uniformMatrix4fv(
+    ~context,
+    ~location=pMatrixUniform,
+    ~value=camera.projectionMatrix
+  );
 
-  /** Get attribute and uniform locations for later usage in the draw code. **/
+  /*** Get attribute and uniform locations for later usage in the draw code. **/
   let aTextureCoord =
-    Gl.getAttribLocation ::context ::program name::"aTextureCoord";
-  Gl.enableVertexAttribArray ::context attribute::aTextureCoord;
+    Gl.getAttribLocation(~context, ~program, ~name="aTextureCoord");
+  Gl.enableVertexAttribArray(~context, ~attribute=aTextureCoord);
 
-  /** Generate texture buffer that we'll use to pass image data around. **/
-  let texture = Gl.createTexture ::context;
+  /*** Generate texture buffer that we'll use to pass image data around. **/
+  let texture = Gl.createTexture(~context);
 
-  /** This tells OpenGL that we're going to be using texture0. OpenGL imposes a limit on the number of
-      texture we can manipulate at the same time. That limit depends on the device. We don't care as we'll just
-      always use texture0. **/
-  Gl.activeTexture ::context RGLConstants.texture0;
+  /*** This tells OpenGL that we're going to be using texture0. OpenGL imposes a limit on the number of
+       texture we can manipulate at the same time. That limit depends on the device. We don't care as we'll just
+       always use texture0. **/
+  Gl.activeTexture(~context, RGLConstants.texture0);
 
-  /** Bind `texture` to `texture_2d` to modify it's magnification and minification params. **/
-  Gl.bindTexture ::context target::RGLConstants.texture_2d ::texture;
-  let uSampler = Gl.getUniformLocation ::context ::program name::"uSampler";
+  /*** Bind `texture` to `texture_2d` to modify it's magnification and minification params. **/
+  Gl.bindTexture(~context, ~target=RGLConstants.texture_2d, ~texture);
+  let uSampler = Gl.getUniformLocation(~context, ~program, ~name="uSampler");
 
-  /** Load a dummy texture. This is because we're using the same shader for things with and without a texture */
-  Gl.texImage2D_RGBA
-    ::context
-    target::RGLConstants.texture_2d
-    level::0
-    width::1
-    height::1
-    border::0
-    data::(Gl.Bigarray.of_array Gl.Bigarray.Uint8 [|0, 0, 0, 0|]);
-  Gl.texParameteri
-    ::context
-    target::RGLConstants.texture_2d
-    pname::RGLConstants.texture_mag_filter
-    param::RGLConstants.linear;
-  Gl.texParameteri
-    ::context
-    target::RGLConstants.texture_2d
-    pname::RGLConstants.texture_min_filter
-    param::RGLConstants.linear_mipmap_nearest;
+  /*** Load a dummy texture. This is because we're using the same shader for things with and without a texture */
+  Gl.texImage2D_RGBA(
+    ~context,
+    ~target=RGLConstants.texture_2d,
+    ~level=0,
+    ~width=1,
+    ~height=1,
+    ~border=0,
+    ~data=Gl.Bigarray.of_array(Gl.Bigarray.Uint8, [|0, 0, 0, 0|])
+  );
+  Gl.texParameteri(
+    ~context,
+    ~target=RGLConstants.texture_2d,
+    ~pname=RGLConstants.texture_mag_filter,
+    ~param=RGLConstants.linear
+  );
+  Gl.texParameteri(
+    ~context,
+    ~target=RGLConstants.texture_2d,
+    ~pname=RGLConstants.texture_min_filter,
+    ~param=RGLConstants.linear_mipmap_nearest
+  );
 
-  /** Enable blend and tell OpenGL how to blend. */
-  Gl.enable ::context RGLConstants.blend;
-  Gl.blendFunc
-    ::context RGLConstants.src_alpha RGLConstants.one_minus_src_alpha;
+  /*** Enable blend and tell OpenGL how to blend. */
+  Gl.enable(~context, RGLConstants.blend);
+  Gl.blendFunc(
+    ~context,
+    RGLConstants.src_alpha,
+    RGLConstants.one_minus_src_alpha
+  );
 
-  /**
+  /***
    * Will mutate the projectionMatrix to be an ortho matrix with the given boundaries.
    * See this link for quick explanation of what this is.
    * https://shearer12345.github.io/graphics/assets/projectionPerspectiveVSOrthographic.png
    */
-  Gl.Mat4.ortho
-    out::camera.projectionMatrix
-    left::0.
-    right::(float_of_int width)
-    bottom::(float_of_int height)
-    top::0.
-    near::0.
-    far::1.;
+  Gl.Mat4.ortho(
+    ~out=camera.projectionMatrix,
+    ~left=0.,
+    ~right=float_of_int(width),
+    ~bottom=float_of_int(height),
+    ~top=0.,
+    ~near=0.,
+    ~far=1.
+  );
   {
     camera,
     window,
     gl: context,
     batch: {
       vertexArray:
-        Gl.Bigarray.create
-          Gl.Bigarray.Float32 (circularBufferSize * vertexSize),
-      elementArray: Gl.Bigarray.create Gl.Bigarray.Uint16 circularBufferSize,
+        Gl.Bigarray.create(
+          Gl.Bigarray.Float32,
+          circularBufferSize * vertexSize
+        ),
+      elementArray: Gl.Bigarray.create(Gl.Bigarray.Uint16, circularBufferSize),
       vertexPtr: 0,
       elementPtr: 0,
       currTex: None,
@@ -175,95 +200,112 @@ let createCanvas window (height: int) (width: int) :glEnv => {
     keyboard: {keyCode: Reprocessing_Events.Nothing},
     mouse: {pos: (0, 0), prevPos: (0, 0), pressed: false},
     style: {
-      fillColor: Some {r: 0., g: 0., b: 0., a: 1.},
+      fillColor: Some({r: 0., g: 0., b: 0., a: 1.}),
       strokeWeight: 3,
       strokeCap: Round,
       strokeColor: None
     },
     styleStack: [],
-    matrix: Matrix.createIdentity (),
+    matrix: Matrix.createIdentity(),
     matrixStack: [],
     frame: {count: 1, rate: 10, deltaTime: 0.001},
     size: {height, width, resizeable: true}
   }
 };
 
-let drawGeometry
-    vertexArray::(vertexArray: Gl.Bigarray.t float Gl.Bigarray.float32_elt)
-    elementArray::(
-      elementArray: Gl.Bigarray.t int Gl.Bigarray.int16_unsigned_elt
-    )
-    ::mode
-    ::count
-    ::textureBuffer
-    env => {
+let drawGeometry =
+    (
+      ~vertexArray: Gl.Bigarray.t(float, Gl.Bigarray.float32_elt),
+      ~elementArray: Gl.Bigarray.t(int, Gl.Bigarray.int16_unsigned_elt),
+      ~mode,
+      ~count,
+      ~textureBuffer,
+      env
+    ) => {
   /* Bind `vertexBuffer`, a pointer to chunk of memory to be sent to the GPU to the "register" called
      `array_buffer` */
-  Gl.bindBuffer
-    context::env.gl target::RGLConstants.array_buffer buffer::env.vertexBuffer;
+  Gl.bindBuffer(
+    ~context=env.gl,
+    ~target=RGLConstants.array_buffer,
+    ~buffer=env.vertexBuffer
+  );
 
-  /** Copy all of the data over into whatever's in `array_buffer` (so here it's `vertexBuffer`) **/
-  Gl.bufferData
-    context::env.gl
-    target::RGLConstants.array_buffer
-    data::vertexArray
-    usage::RGLConstants.stream_draw;
+  /*** Copy all of the data over into whatever's in `array_buffer` (so here it's `vertexBuffer`) **/
+  Gl.bufferData(
+    ~context=env.gl,
+    ~target=RGLConstants.array_buffer,
+    ~data=vertexArray,
+    ~usage=RGLConstants.stream_draw
+  );
 
-  /** Tell the GPU about the shader attribute called `aVertexPosition` so it can access the data per vertex */
-  Gl.vertexAttribPointer
-    context::env.gl
-    attribute::env.aVertexPosition
-    size::2
-    type_::RGLConstants.float_
-    normalize::false
-    stride::(vertexSize * 4)
-    offset::0;
+  /*** Tell the GPU about the shader attribute called `aVertexPosition` so it can access the data per vertex */
+  Gl.vertexAttribPointer(
+    ~context=env.gl,
+    ~attribute=env.aVertexPosition,
+    ~size=2,
+    ~type_=RGLConstants.float_,
+    ~normalize=false,
+    ~stride=vertexSize * 4,
+    ~offset=0
+  );
 
-  /** Same as above but for `aVertexColor` **/
-  Gl.vertexAttribPointer
-    context::env.gl
-    attribute::env.aVertexColor
-    size::4
-    type_::RGLConstants.float_
-    normalize::false
-    stride::(vertexSize * 4)
-    offset::(2 * 4);
+  /*** Same as above but for `aVertexColor` **/
+  Gl.vertexAttribPointer(
+    ~context=env.gl,
+    ~attribute=env.aVertexColor,
+    ~size=4,
+    ~type_=RGLConstants.float_,
+    ~normalize=false,
+    ~stride=vertexSize * 4,
+    ~offset=2 * 4
+  );
 
-  /** Same as above but for `aTextureCoord` **/
-  Gl.vertexAttribPointer
-    context::env.gl
-    attribute::env.aTextureCoord
-    size::2
-    type_::RGLConstants.float_
-    normalize::false
-    stride::(vertexSize * 4)
-    offset::(6 * 4);
+  /*** Same as above but for `aTextureCoord` **/
+  Gl.vertexAttribPointer(
+    ~context=env.gl,
+    ~attribute=env.aTextureCoord,
+    ~size=2,
+    ~type_=RGLConstants.float_,
+    ~normalize=false,
+    ~stride=vertexSize * 4,
+    ~offset=6 * 4
+  );
 
-  /** Tell OpenGL about what the uniform called `uSampler` is pointing at, here it's given 0 which is what
-      texture0 represent.  **/
-  Gl.uniform1i context::env.gl location::env.uSampler val::0;
+  /*** Tell OpenGL about what the uniform called `uSampler` is pointing at, here it's given 0 which is what
+       texture0 represent.  **/
+  Gl.uniform1i(~context=env.gl, ~location=env.uSampler, ~val=0);
 
-  /** Bind `elementBuffer`, a pointer to GPU memory to `element_array_buffer`. That "register" is used for
-      the data representing the indices of the vertex. **/
-  Gl.bindBuffer
-    context::env.gl
-    target::RGLConstants.element_array_buffer
-    buffer::env.elementBuffer;
+  /*** Bind `elementBuffer`, a pointer to GPU memory to `element_array_buffer`. That "register" is used for
+       the data representing the indices of the vertex. **/
+  Gl.bindBuffer(
+    ~context=env.gl,
+    ~target=RGLConstants.element_array_buffer,
+    ~buffer=env.elementBuffer
+  );
 
-  /** Copy the `elementArray` into whatever buffer is in `element_array_buffer` **/
-  Gl.bufferData
-    context::env.gl
-    target::RGLConstants.element_array_buffer
-    data::elementArray
-    usage::RGLConstants.stream_draw;
+  /*** Copy the `elementArray` into whatever buffer is in `element_array_buffer` **/
+  Gl.bufferData(
+    ~context=env.gl,
+    ~target=RGLConstants.element_array_buffer,
+    ~data=elementArray,
+    ~usage=RGLConstants.stream_draw
+  );
 
-  /** We bind `texture` to texture_2d, like we did for the vertex buffers in some ways (I think?) **/
-  Gl.bindTexture
-    context::env.gl target::RGLConstants.texture_2d texture::textureBuffer;
+  /*** We bind `texture` to texture_2d, like we did for the vertex buffers in some ways (I think?) **/
+  Gl.bindTexture(
+    ~context=env.gl,
+    ~target=RGLConstants.texture_2d,
+    ~texture=textureBuffer
+  );
 
-  /** Final call which actually tells the GPU to draw. **/
-  Gl.drawElements
-    context::env.gl ::mode ::count type_::RGLConstants.unsigned_short offset::0
+  /*** Final call which actually tells the GPU to draw. **/
+  Gl.drawElements(
+    ~context=env.gl,
+    ~mode,
+    ~count,
+    ~type_=RGLConstants.unsigned_short,
+    ~offset=0
+  )
 };
 
 /*
@@ -273,45 +315,44 @@ let drawGeometry
  * That function creates a new big array with a new size given the offset and len but does NOT copy the
  * underlying array of memory. So mutation done to that sub array will be reflected in the original one.
  */
-let flushGlobalBatch env =>
+let flushGlobalBatch = (env) =>
   if (env.batch.elementPtr > 0) {
     let textureBuffer =
       switch env.batch.currTex {
       | None => env.batch.nullTex
-      | Some textureBuffer => textureBuffer
+      | Some(textureBuffer) => textureBuffer
       };
-    drawGeometry
-      vertexArray::(
-        Gl.Bigarray.sub
-          env.batch.vertexArray offset::0 len::env.batch.vertexPtr
-      )
-      elementArray::(
-        Gl.Bigarray.sub
-          env.batch.elementArray offset::0 len::env.batch.elementPtr
-      )
-      mode::RGLConstants.triangles
-      count::env.batch.elementPtr
-      ::textureBuffer
-      env;
+    drawGeometry(
+      ~vertexArray=
+        Gl.Bigarray.sub(
+          env.batch.vertexArray,
+          ~offset=0,
+          ~len=env.batch.vertexPtr
+        ),
+      ~elementArray=
+        Gl.Bigarray.sub(
+          env.batch.elementArray,
+          ~offset=0,
+          ~len=env.batch.elementPtr
+        ),
+      ~mode=RGLConstants.triangles,
+      ~count=env.batch.elementPtr,
+      ~textureBuffer,
+      env
+    );
     env.batch.currTex = None;
     env.batch.vertexPtr = 0;
     env.batch.elementPtr = 0
   };
 
-let maybeFlushBatch ::texture ::el ::vert env =>
-  if (
-    env.batch.elementPtr
-    + el
-    >= circularBufferSize
-    || env.batch.vertexPtr
-    + vert
-    >= circularBufferSize
-    || env.batch.elementPtr
-    > 0
-    && env.batch.currTex
-    !== texture
-  ) {
-    flushGlobalBatch env
+let maybeFlushBatch = (~texture, ~el, ~vert, env) =>
+  if (env.batch.elementPtr
+      + el >= circularBufferSize
+      || env.batch.vertexPtr
+      + vert >= circularBufferSize
+      || env.batch.elementPtr > 0
+      && env.batch.currTex !== texture) {
+    flushGlobalBatch(env)
   };
 
 /*
@@ -337,105 +378,108 @@ let maybeFlushBatch ::texture ::el ::vert env =>
  * triangles: one with the vertices 0, 1 and 2 from the vertex array, and one with the vertices 1, 2 and 3.
  * We can "point" to duplicated vertices in our geometry to avoid sending those vertices.
  */
-let addRectToGlobalBatch
-    env
-    bottomRight::(x1, y1)
-    bottomLeft::(x2, y2)
-    topRight::(x3, y3)
-    topLeft::(x4, y4)
-    color::{r, g, b, a} => {
-  maybeFlushBatch texture::None el::6 vert::32 env;
+let addRectToGlobalBatch =
+    (
+      env,
+      ~bottomRight as (x1, y1),
+      ~bottomLeft as (x2, y2),
+      ~topRight as (x3, y3),
+      ~topLeft as (x4, y4),
+      ~color as {r, g, b, a}
+    ) => {
+  maybeFlushBatch(~texture=None, ~el=6, ~vert=32, env);
   let set = Gl.Bigarray.set;
   let i = env.batch.vertexPtr;
   let vertexArrayToMutate = env.batch.vertexArray;
-  set vertexArrayToMutate (i + 0) x1;
-  set vertexArrayToMutate (i + 1) y1;
-  set vertexArrayToMutate (i + 2) r;
-  set vertexArrayToMutate (i + 3) g;
-  set vertexArrayToMutate (i + 4) b;
-  set vertexArrayToMutate (i + 5) a;
-  set vertexArrayToMutate (i + 6) 0.0;
-  set vertexArrayToMutate (i + 7) 0.0;
-  set vertexArrayToMutate (i + 8) x2;
-  set vertexArrayToMutate (i + 9) y2;
-  set vertexArrayToMutate (i + 10) r;
-  set vertexArrayToMutate (i + 11) g;
-  set vertexArrayToMutate (i + 12) b;
-  set vertexArrayToMutate (i + 13) a;
-  set vertexArrayToMutate (i + 14) 0.0;
-  set vertexArrayToMutate (i + 15) 0.0;
-  set vertexArrayToMutate (i + 16) x3;
-  set vertexArrayToMutate (i + 17) y3;
-  set vertexArrayToMutate (i + 18) r;
-  set vertexArrayToMutate (i + 19) g;
-  set vertexArrayToMutate (i + 20) b;
-  set vertexArrayToMutate (i + 21) a;
-  set vertexArrayToMutate (i + 22) 0.0;
-  set vertexArrayToMutate (i + 23) 0.0;
-  set vertexArrayToMutate (i + 24) x4;
-  set vertexArrayToMutate (i + 25) y4;
-  set vertexArrayToMutate (i + 26) r;
-  set vertexArrayToMutate (i + 27) g;
-  set vertexArrayToMutate (i + 28) b;
-  set vertexArrayToMutate (i + 29) a;
-  set vertexArrayToMutate (i + 30) 0.0;
-  set vertexArrayToMutate (i + 31) 0.0;
+  set(vertexArrayToMutate, i + 0, x1);
+  set(vertexArrayToMutate, i + 1, y1);
+  set(vertexArrayToMutate, i + 2, r);
+  set(vertexArrayToMutate, i + 3, g);
+  set(vertexArrayToMutate, i + 4, b);
+  set(vertexArrayToMutate, i + 5, a);
+  set(vertexArrayToMutate, i + 6, 0.0);
+  set(vertexArrayToMutate, i + 7, 0.0);
+  set(vertexArrayToMutate, i + 8, x2);
+  set(vertexArrayToMutate, i + 9, y2);
+  set(vertexArrayToMutate, i + 10, r);
+  set(vertexArrayToMutate, i + 11, g);
+  set(vertexArrayToMutate, i + 12, b);
+  set(vertexArrayToMutate, i + 13, a);
+  set(vertexArrayToMutate, i + 14, 0.0);
+  set(vertexArrayToMutate, i + 15, 0.0);
+  set(vertexArrayToMutate, i + 16, x3);
+  set(vertexArrayToMutate, i + 17, y3);
+  set(vertexArrayToMutate, i + 18, r);
+  set(vertexArrayToMutate, i + 19, g);
+  set(vertexArrayToMutate, i + 20, b);
+  set(vertexArrayToMutate, i + 21, a);
+  set(vertexArrayToMutate, i + 22, 0.0);
+  set(vertexArrayToMutate, i + 23, 0.0);
+  set(vertexArrayToMutate, i + 24, x4);
+  set(vertexArrayToMutate, i + 25, y4);
+  set(vertexArrayToMutate, i + 26, r);
+  set(vertexArrayToMutate, i + 27, g);
+  set(vertexArrayToMutate, i + 28, b);
+  set(vertexArrayToMutate, i + 29, a);
+  set(vertexArrayToMutate, i + 30, 0.0);
+  set(vertexArrayToMutate, i + 31, 0.0);
   let ii = i / vertexSize;
   let j = env.batch.elementPtr;
   let elementArrayToMutate = env.batch.elementArray;
-  set elementArrayToMutate (j + 0) ii;
-  set elementArrayToMutate (j + 1) (ii + 1);
-  set elementArrayToMutate (j + 2) (ii + 2);
-  set elementArrayToMutate (j + 3) (ii + 1);
-  set elementArrayToMutate (j + 4) (ii + 2);
-  set elementArrayToMutate (j + 5) (ii + 3);
+  set(elementArrayToMutate, j + 0, ii);
+  set(elementArrayToMutate, j + 1, ii + 1);
+  set(elementArrayToMutate, j + 2, ii + 2);
+  set(elementArrayToMutate, j + 3, ii + 1);
+  set(elementArrayToMutate, j + 4, ii + 2);
+  set(elementArrayToMutate, j + 5, ii + 3);
   env.batch.vertexPtr = i + 4 * vertexSize;
   env.batch.elementPtr = j + 6
 };
 
-let drawTriangle env (x1, y1) (x2, y2) (x3, y3) color::{r, g, b, a} => {
-  maybeFlushBatch texture::None vert::3 el::24 env;
+let drawTriangle = (env, (x1, y1), (x2, y2), (x3, y3), ~color as {r, g, b, a}) => {
+  maybeFlushBatch(~texture=None, ~vert=3, ~el=24, env);
   let set = Gl.Bigarray.set;
   let i = env.batch.vertexPtr;
   let vertexArrayToMutate = env.batch.vertexArray;
-  set vertexArrayToMutate (i + 0) x1;
-  set vertexArrayToMutate (i + 1) y1;
-  set vertexArrayToMutate (i + 2) r;
-  set vertexArrayToMutate (i + 3) g;
-  set vertexArrayToMutate (i + 4) b;
-  set vertexArrayToMutate (i + 5) a;
-  set vertexArrayToMutate (i + 6) 0.0;
-  set vertexArrayToMutate (i + 7) 0.0;
-  set vertexArrayToMutate (i + 8) x2;
-  set vertexArrayToMutate (i + 9) y2;
-  set vertexArrayToMutate (i + 10) r;
-  set vertexArrayToMutate (i + 11) g;
-  set vertexArrayToMutate (i + 12) b;
-  set vertexArrayToMutate (i + 13) a;
-  set vertexArrayToMutate (i + 14) 0.0;
-  set vertexArrayToMutate (i + 15) 0.0;
-  set vertexArrayToMutate (i + 16) x3;
-  set vertexArrayToMutate (i + 17) y3;
-  set vertexArrayToMutate (i + 18) r;
-  set vertexArrayToMutate (i + 19) g;
-  set vertexArrayToMutate (i + 20) b;
-  set vertexArrayToMutate (i + 21) a;
-  set vertexArrayToMutate (i + 22) 0.0;
-  set vertexArrayToMutate (i + 23) 0.0;
+  set(vertexArrayToMutate, i + 0, x1);
+  set(vertexArrayToMutate, i + 1, y1);
+  set(vertexArrayToMutate, i + 2, r);
+  set(vertexArrayToMutate, i + 3, g);
+  set(vertexArrayToMutate, i + 4, b);
+  set(vertexArrayToMutate, i + 5, a);
+  set(vertexArrayToMutate, i + 6, 0.0);
+  set(vertexArrayToMutate, i + 7, 0.0);
+  set(vertexArrayToMutate, i + 8, x2);
+  set(vertexArrayToMutate, i + 9, y2);
+  set(vertexArrayToMutate, i + 10, r);
+  set(vertexArrayToMutate, i + 11, g);
+  set(vertexArrayToMutate, i + 12, b);
+  set(vertexArrayToMutate, i + 13, a);
+  set(vertexArrayToMutate, i + 14, 0.0);
+  set(vertexArrayToMutate, i + 15, 0.0);
+  set(vertexArrayToMutate, i + 16, x3);
+  set(vertexArrayToMutate, i + 17, y3);
+  set(vertexArrayToMutate, i + 18, r);
+  set(vertexArrayToMutate, i + 19, g);
+  set(vertexArrayToMutate, i + 20, b);
+  set(vertexArrayToMutate, i + 21, a);
+  set(vertexArrayToMutate, i + 22, 0.0);
+  set(vertexArrayToMutate, i + 23, 0.0);
   let ii = i / vertexSize;
   let j = env.batch.elementPtr;
   let elementArrayToMutate = env.batch.elementArray;
-  set elementArrayToMutate (j + 0) ii;
-  set elementArrayToMutate (j + 1) (ii + 1);
-  set elementArrayToMutate (j + 2) (ii + 2);
+  set(elementArrayToMutate, j + 0, ii);
+  set(elementArrayToMutate, j + 1, ii + 1);
+  set(elementArrayToMutate, j + 2, ii + 2);
   env.batch.vertexPtr = i + 3 * vertexSize;
   env.batch.elementPtr = j + 3
 };
 
-let drawLine p1::(xx1, yy1) p2::(xx2, yy2) ::color ::width ::project env => {
+let drawLine =
+    (~p1 as (xx1, yy1), ~p2 as (xx2, yy2), ~color, ~width, ~project, env) => {
   let dx = xx2 -. xx1;
   let dy = yy2 -. yy1;
-  let mag = sqrt (dx *. dx +. dy *. dy);
+  let mag = sqrt(dx *. dx +. dy *. dy);
   let radius = width /. 2.;
   let xthing = dy /. mag *. radius;
   let ything = -. dx /. mag *. radius;
@@ -449,30 +493,33 @@ let drawLine p1::(xx1, yy1) p2::(xx2, yy2) ::color ::width ::project env => {
   let y3 = yy2 -. ything +. projecty;
   let x4 = xx1 -. xthing -. projectx;
   let y4 = yy1 -. ything -. projecty;
-  addRectToGlobalBatch
-    env
-    bottomRight::(x1, y1)
-    bottomLeft::(x2, y2)
-    topRight::(x3, y3)
-    topLeft::(x4, y4)
-    ::color
+  addRectToGlobalBatch(
+    env,
+    ~bottomRight=(x1, y1),
+    ~bottomLeft=(x2, y2),
+    ~topRight=(x3, y3),
+    ~topLeft=(x4, y4),
+    ~color
+  )
 };
 
-let drawArc
-    env
-    (xCenterOfCircle: float, yCenterOfCircle: float)
-    (radx: float)
-    (rady: float)
-    (start: float)
-    (stop: float)
-    (isPie: bool)
-    (matrix: array float)
-    {r, g, b, a} => {
-  let transform = Matrix.matptmul matrix;
-  let noOfFans = int_of_float (radx +. rady) / 4 + 10;
-  maybeFlushBatch texture::None vert::(8 * noOfFans) el::(3 * noOfFans) env;
-  let pi = 4.0 *. atan 1.0;
-  let anglePerFan = 2. *. pi /. float_of_int noOfFans;
+let drawArc =
+    (
+      env,
+      (xCenterOfCircle: float, yCenterOfCircle: float),
+      radx: float,
+      rady: float,
+      start: float,
+      stop: float,
+      isPie: bool,
+      matrix: array(float),
+      {r, g, b, a}
+    ) => {
+  let transform = Matrix.matptmul(matrix);
+  let noOfFans = int_of_float(radx +. rady) / 4 + 10;
+  maybeFlushBatch(~texture=None, ~vert=8 * noOfFans, ~el=3 * noOfFans, env);
+  let pi = 4.0 *. atan(1.0);
+  let anglePerFan = 2. *. pi /. float_of_int(noOfFans);
   let verticesData = env.batch.vertexArray;
   let elementData = env.batch.elementArray;
   let set = Gl.Bigarray.set;
@@ -480,17 +527,17 @@ let drawArc
   let vertexArrayOffset = env.batch.vertexPtr;
   let elementArrayOffset = env.batch.elementPtr;
   let start_i =
-    if isPie {
+    if (isPie) {
       /* Start one earlier and force the first point to be the center */
-      int_of_float (start /. anglePerFan)
+      int_of_float(start /. anglePerFan)
       - 2
     } else {
-      int_of_float (start /. anglePerFan) - 1
+      int_of_float(start /. anglePerFan) - 1
     };
-  let stop_i = int_of_float (stop /. anglePerFan) - 1;
-  for i in start_i to stop_i {
+  let stop_i = int_of_float(stop /. anglePerFan) - 1;
+  for (i in start_i to stop_i) {
     let (xCoordinate, yCoordinate) =
-      transform (
+      transform(
         if (isPie && i - start_i == 0) {
           (
             /* force the first point to be the center */
@@ -498,27 +545,27 @@ let drawArc
             yCenterOfCircle
           )
         } else {
-          let angle = anglePerFan *. float_of_int (i + 1);
+          let angle = anglePerFan *. float_of_int(i + 1);
           (
-            xCenterOfCircle +. cos angle *. radx,
-            yCenterOfCircle +. sin angle *. rady
+            xCenterOfCircle +. cos(angle) *. radx,
+            yCenterOfCircle +. sin(angle) *. rady
           )
         }
       );
     let ii = (i - start_i) * vertexSize + vertexArrayOffset;
-    set verticesData (ii + 0) xCoordinate;
-    set verticesData (ii + 1) yCoordinate;
-    set verticesData (ii + 2) r;
-    set verticesData (ii + 3) g;
-    set verticesData (ii + 4) b;
-    set verticesData (ii + 5) a;
-    set verticesData (ii + 6) 0.0;
-    set verticesData (ii + 7) 0.0;
+    set(verticesData, ii + 0, xCoordinate);
+    set(verticesData, ii + 1, yCoordinate);
+    set(verticesData, ii + 2, r);
+    set(verticesData, ii + 3, g);
+    set(verticesData, ii + 4, b);
+    set(verticesData, ii + 5, a);
+    set(verticesData, ii + 6, 0.0);
+    set(verticesData, ii + 7, 0.0);
     /* For the first three vertices, we don't do any deduping. Then for the subsequent ones, we'll actually
        have 3 elements, one pointing at the first vertex, one pointing at the previously added vertex and one
        pointing at the current vertex. This mimicks the behavior of triangle_fan. */
     if (i - start_i < 3) {
-      set elementData (i - start_i + elementArrayOffset) (ii / vertexSize)
+      set(elementData, i - start_i + elementArrayOffset, ii / vertexSize)
     } else {
       /* We've already added 3 elements, for i = 0, 1 and 2. From now on, we'll add 3 elements _per_ i.
          To calculate the correct offset in `elementData` we remove 3 from i as if we're starting from 0 (the
@@ -526,293 +573,328 @@ let drawArc
          i = 3 we want `jj` to be 3 so we shift everything by 3 (so add 3). Everything's also shifted by
          `elementArrayOffset` */
       let jj = (i - start_i - 3) * 3 + elementArrayOffset + 3;
-      set elementData jj (vertexArrayOffset / vertexSize);
-      set elementData (jj + 1) (get elementData (jj - 1));
-      set elementData (jj + 2) (ii / vertexSize)
+      set(elementData, jj, vertexArrayOffset / vertexSize);
+      set(elementData, jj + 1, get(elementData, jj - 1));
+      set(elementData, jj + 2, ii / vertexSize)
     }
   };
   env.batch.vertexPtr = env.batch.vertexPtr + noOfFans * vertexSize;
   env.batch.elementPtr = env.batch.elementPtr + (stop_i - start_i - 3) * 3 + 3
 };
 
-let drawEllipse env center (radx: float) (rady: float) (matrix: array float) c =>
-  drawArc env center radx rady 0. Reprocessing_Constants.tau false matrix c;
+let drawEllipse =
+    (env, center, radx: float, rady: float, matrix: array(float), c) =>
+  drawArc(
+    env,
+    center,
+    radx,
+    rady,
+    0.,
+    Reprocessing_Constants.tau,
+    false,
+    matrix,
+    c
+  );
 
-let drawArcStroke
-    env
-    (xCenterOfCircle: float, yCenterOfCircle: float)
-    (radx: float)
-    (rady: float)
-    (start: float)
-    (stop: float)
-    (isOpen: bool)
-    (isPie: bool)
-    (matrix: array float)
-    ({r, g, b, a} as strokeColor)
-    strokeWidth => {
-  let transform = Matrix.matptmul matrix;
+let drawArcStroke =
+    (
+      env,
+      (xCenterOfCircle: float, yCenterOfCircle: float),
+      radx: float,
+      rady: float,
+      start: float,
+      stop: float,
+      isOpen: bool,
+      isPie: bool,
+      matrix: array(float),
+      {r, g, b, a} as strokeColor,
+      strokeWidth
+    ) => {
+  let transform = Matrix.matptmul(matrix);
   let verticesData = env.batch.vertexArray;
   let elementData = env.batch.elementArray;
-  let noOfFans = int_of_float (radx +. rady) / 4 + 10;
+  let noOfFans = int_of_float(radx +. rady) / 4 + 10;
   let set = Gl.Bigarray.set;
-  maybeFlushBatch texture::None vert::16 el::6 env;
-  let pi = 4.0 *. atan 1.0;
-  let anglePerFan = 2. *. pi /. float_of_int noOfFans;
+  maybeFlushBatch(~texture=None, ~vert=16, ~el=6, env);
+  let pi = 4.0 *. atan(1.0);
+  let anglePerFan = 2. *. pi /. float_of_int(noOfFans);
   /* I calculated this roughly by doing:
      anglePerFan *. float_of_int (i + 1) == start
      i+1 == start /. anglePerFan
      */
-  let start_i = int_of_float (start /. anglePerFan) - 1;
-  let stop_i = int_of_float (stop /. anglePerFan) - 1;
-  let prevEl: ref (option (int, int)) = ref None;
-  let halfwidth = float_of_int strokeWidth /. 2.;
-  for i in start_i to stop_i {
-    let angle = anglePerFan *. float_of_int (i + 1);
+  let start_i = int_of_float(start /. anglePerFan) - 1;
+  let stop_i = int_of_float(stop /. anglePerFan) - 1;
+  let prevEl: ref(option((int, int))) = ref(None);
+  let halfwidth = float_of_int(strokeWidth) /. 2.;
+  for (i in start_i to stop_i) {
+    let angle = anglePerFan *. float_of_int(i + 1);
     let (xCoordinateInner, yCoordinateInner) =
-      transform (
-        xCenterOfCircle +. cos angle *. (radx -. halfwidth),
-        yCenterOfCircle +. sin angle *. (rady -. halfwidth)
-      );
+      transform((
+        xCenterOfCircle +. cos(angle) *. (radx -. halfwidth),
+        yCenterOfCircle +. sin(angle) *. (rady -. halfwidth)
+      ));
     let (xCoordinateOuter, yCoordinateOuter) =
-      transform (
-        xCenterOfCircle +. cos angle *. (radx +. halfwidth),
-        yCenterOfCircle +. sin angle *. (rady +. halfwidth)
-      );
+      transform((
+        xCenterOfCircle +. cos(angle) *. (radx +. halfwidth),
+        yCenterOfCircle +. sin(angle) *. (rady +. halfwidth)
+      ));
     let ii = env.batch.vertexPtr;
-    set verticesData (ii + 0) xCoordinateInner;
-    set verticesData (ii + 1) yCoordinateInner;
-    set verticesData (ii + 2) r;
-    set verticesData (ii + 3) g;
-    set verticesData (ii + 4) b;
-    set verticesData (ii + 5) a;
-    set verticesData (ii + 6) 0.0;
-    set verticesData (ii + 7) 0.0;
+    set(verticesData, ii + 0, xCoordinateInner);
+    set(verticesData, ii + 1, yCoordinateInner);
+    set(verticesData, ii + 2, r);
+    set(verticesData, ii + 3, g);
+    set(verticesData, ii + 4, b);
+    set(verticesData, ii + 5, a);
+    set(verticesData, ii + 6, 0.0);
+    set(verticesData, ii + 7, 0.0);
     let ii = ii + vertexSize;
-    set verticesData (ii + 0) xCoordinateOuter;
-    set verticesData (ii + 1) yCoordinateOuter;
-    set verticesData (ii + 2) r;
-    set verticesData (ii + 3) g;
-    set verticesData (ii + 4) b;
-    set verticesData (ii + 5) a;
-    set verticesData (ii + 6) 0.0;
-    set verticesData (ii + 7) 0.0;
+    set(verticesData, ii + 0, xCoordinateOuter);
+    set(verticesData, ii + 1, yCoordinateOuter);
+    set(verticesData, ii + 2, r);
+    set(verticesData, ii + 3, g);
+    set(verticesData, ii + 4, b);
+    set(verticesData, ii + 5, a);
+    set(verticesData, ii + 6, 0.0);
+    set(verticesData, ii + 7, 0.0);
     env.batch.vertexPtr = env.batch.vertexPtr + vertexSize * 2;
     let currOuter = ii / vertexSize;
     let currInner = ii / vertexSize - 1;
-    let currEl = Some (currInner, currOuter);
-    switch !prevEl {
+    let currEl = Some((currInner, currOuter));
+    switch prevEl^ {
     | None => prevEl := currEl
-    | Some (prevInner, prevOuter) =>
+    | Some((prevInner, prevOuter)) =>
       let elementArrayOffset = env.batch.elementPtr;
-      set elementData elementArrayOffset prevInner;
-      set elementData (elementArrayOffset + 1) prevOuter;
-      set elementData (elementArrayOffset + 2) currOuter;
-      set elementData (elementArrayOffset + 3) currOuter;
-      set elementData (elementArrayOffset + 4) prevInner;
-      set elementData (elementArrayOffset + 5) currInner;
+      set(elementData, elementArrayOffset, prevInner);
+      set(elementData, elementArrayOffset + 1, prevOuter);
+      set(elementData, elementArrayOffset + 2, currOuter);
+      set(elementData, elementArrayOffset + 3, currOuter);
+      set(elementData, elementArrayOffset + 4, prevInner);
+      set(elementData, elementArrayOffset + 5, currInner);
       env.batch.elementPtr = env.batch.elementPtr + 6;
       prevEl := currEl
     }
   };
-  if (not isOpen) {
+  if (! isOpen) {
     let (startX, startY) =
-      transform (
-        xCenterOfCircle +. cos start *. radx,
-        yCenterOfCircle +. sin start *. rady
-      );
+      transform((
+        xCenterOfCircle +. cos(start) *. radx,
+        yCenterOfCircle +. sin(start) *. rady
+      ));
     let (stopX, stopY) =
-      transform (
-        xCenterOfCircle +. cos stop *. radx,
-        yCenterOfCircle +. sin stop *. rady
+      transform((
+        xCenterOfCircle +. cos(stop) *. radx,
+        yCenterOfCircle +. sin(stop) *. rady
+      ));
+    if (isPie) {
+      drawLine(
+        ~p1=(startX, startY),
+        ~p2=(xCenterOfCircle, yCenterOfCircle),
+        ~color=strokeColor,
+        ~width=halfwidth,
+        ~project=false,
+        env
       );
-    if isPie {
-      drawLine
-        p1::(startX, startY)
-        p2::(xCenterOfCircle, yCenterOfCircle)
-        color::strokeColor
-        width::halfwidth
-        project::false
-        env;
-      drawLine
-        p1::(stopX, stopY)
-        p2::(xCenterOfCircle, yCenterOfCircle)
-        color::strokeColor
-        width::halfwidth
-        project::false
-        env;
-      drawEllipse
+      drawLine(
+        ~p1=(stopX, stopY),
+        ~p2=(xCenterOfCircle, yCenterOfCircle),
+        ~color=strokeColor,
+        ~width=halfwidth,
+        ~project=false,
         env
-        (transform (xCenterOfCircle, yCenterOfCircle))
-        halfwidth
-        halfwidth
-        matrix
+      );
+      drawEllipse(
+        env,
+        transform((xCenterOfCircle, yCenterOfCircle)),
+        halfwidth,
+        halfwidth,
+        matrix,
         strokeColor
+      )
     } else {
-      drawLine
-        p1::(startX, startY)
-        p2::(stopX, stopY)
-        color::strokeColor
-        width::halfwidth
-        project::false
+      drawLine(
+        ~p1=(startX, startY),
+        ~p2=(stopX, stopY),
+        ~color=strokeColor,
+        ~width=halfwidth,
+        ~project=false,
         env
+      )
     };
-    drawEllipse env (startX, startY) halfwidth halfwidth matrix strokeColor;
-    drawEllipse env (stopX, stopY) halfwidth halfwidth matrix strokeColor
+    drawEllipse(
+      env,
+      (startX, startY),
+      halfwidth,
+      halfwidth,
+      matrix,
+      strokeColor
+    );
+    drawEllipse(env, (stopX, stopY), halfwidth, halfwidth, matrix, strokeColor)
   }
 };
 
-let loadImage (env: glEnv) filename isPixel :imageT => {
-  let imageRef = ref None;
-  Gl.loadImage
-    ::filename
-    callback::(
-      fun imageData =>
+let loadImage = (env: glEnv, filename, isPixel) : imageT => {
+  let imageRef = ref(None);
+  Gl.loadImage(
+    ~filename,
+    ~callback=
+      (imageData) =>
         switch imageData {
-        | None => failwith ("Could not load image '" ^ filename ^ "'.") /* TODO: handle this better? */
-        | Some img =>
+        | None => failwith("Could not load image '" ++ (filename ++ "'.")) /* TODO: handle this better? */
+        | Some(img) =>
           let env = env;
-          let textureBuffer = Gl.createTexture context::env.gl;
-          let height = Gl.getImageHeight img;
-          let width = Gl.getImageWidth img;
+          let textureBuffer = Gl.createTexture(~context=env.gl);
+          let height = Gl.getImageHeight(img);
+          let width = Gl.getImageWidth(img);
           let filter = isPixel ? Constants.nearest : Constants.linear;
-          imageRef := Some {img, textureBuffer, height, width};
-          Gl.bindTexture
-            context::env.gl
-            target::Constants.texture_2d
-            texture::textureBuffer;
-          Gl.texImage2DWithImage
-            context::env.gl target::Constants.texture_2d level::0 image::img;
-          Gl.texParameteri
-            context::env.gl
-            target::Constants.texture_2d
-            pname::Constants.texture_mag_filter
-            param::filter;
-          Gl.texParameteri
-            context::env.gl
-            target::Constants.texture_2d
-            pname::Constants.texture_min_filter
-            param::filter;
-          Gl.texParameteri
-            context::env.gl
-            target::Constants.texture_2d
-            pname::Constants.texture_wrap_s
-            param::Constants.clamp_to_edge;
-          Gl.texParameteri
-            context::env.gl
-            target::Constants.texture_2d
-            pname::Constants.texture_wrap_t
-            param::Constants.clamp_to_edge
-        }
-    )
-    ();
+          imageRef := Some({img, textureBuffer, height, width});
+          Gl.bindTexture(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~texture=textureBuffer
+          );
+          Gl.texImage2DWithImage(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~level=0,
+            ~image=img
+          );
+          Gl.texParameteri(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~pname=Constants.texture_mag_filter,
+            ~param=filter
+          );
+          Gl.texParameteri(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~pname=Constants.texture_min_filter,
+            ~param=filter
+          );
+          Gl.texParameteri(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~pname=Constants.texture_wrap_s,
+            ~param=Constants.clamp_to_edge
+          );
+          Gl.texParameteri(
+            ~context=env.gl,
+            ~target=Constants.texture_2d,
+            ~pname=Constants.texture_wrap_t,
+            ~param=Constants.clamp_to_edge
+          )
+        },
+    ()
+  );
   imageRef
 };
 
-let drawImage
-    {width: imgw, height: imgh, textureBuffer}
-    p1::(x1, y1)
-    p2::(x2, y2)
-    p3::(x3, y3)
-    p4::(x4, y4)
-    ::subx
-    ::suby
-    ::subw
-    ::subh
-    env => {
-  maybeFlushBatch texture::(Some textureBuffer) vert::32 el::6 env;
+let drawImage =
+    (
+      {width: imgw, height: imgh, textureBuffer},
+      ~p1 as (x1, y1),
+      ~p2 as (x2, y2),
+      ~p3 as (x3, y3),
+      ~p4 as (x4, y4),
+      ~subx,
+      ~suby,
+      ~subw,
+      ~subh,
+      env
+    ) => {
+  maybeFlushBatch(~texture=Some(textureBuffer), ~vert=32, ~el=6, env);
   let (fsubx, fsuby, fsubw, fsubh) = (
-    float_of_int subx /. float_of_int imgw,
-    float_of_int suby /. float_of_int imgh,
-    float_of_int subw /. float_of_int imgw,
-    float_of_int subh /. float_of_int imgh
+    float_of_int(subx) /. float_of_int(imgw),
+    float_of_int(suby) /. float_of_int(imgh),
+    float_of_int(subw) /. float_of_int(imgw),
+    float_of_int(subh) /. float_of_int(imgh)
   );
   let set = Gl.Bigarray.set;
   let ii = env.batch.vertexPtr;
   let vertexArray = env.batch.vertexArray;
-  set vertexArray (ii + 0) x1;
-  set vertexArray (ii + 1) y1;
-  set vertexArray (ii + 2) 0.0;
-  set vertexArray (ii + 3) 0.0;
-  set vertexArray (ii + 4) 0.0;
-  set vertexArray (ii + 5) 0.0;
-  set vertexArray (ii + 6) (fsubx +. fsubw);
-  set vertexArray (ii + 7) (fsuby +. fsubh);
-  set vertexArray (ii + 8) x2;
-  set vertexArray (ii + 9) y2;
-  set vertexArray (ii + 10) 0.0;
-  set vertexArray (ii + 11) 0.0;
-  set vertexArray (ii + 12) 0.0;
-  set vertexArray (ii + 13) 0.0;
-  set vertexArray (ii + 14) fsubx;
-  set vertexArray (ii + 15) (fsuby +. fsubh);
-  set vertexArray (ii + 16) x3;
-  set vertexArray (ii + 17) y3;
-  set vertexArray (ii + 18) 0.0;
-  set vertexArray (ii + 19) 0.0;
-  set vertexArray (ii + 20) 0.0;
-  set vertexArray (ii + 21) 0.0;
-  set vertexArray (ii + 22) (fsubx +. fsubw);
-  set vertexArray (ii + 23) fsuby;
-  set vertexArray (ii + 24) x4;
-  set vertexArray (ii + 25) y4;
-  set vertexArray (ii + 26) 0.0;
-  set vertexArray (ii + 27) 0.0;
-  set vertexArray (ii + 28) 0.0;
-  set vertexArray (ii + 29) 0.0;
-  set vertexArray (ii + 30) fsubx;
-  set vertexArray (ii + 31) fsuby;
+  set(vertexArray, ii + 0, x1);
+  set(vertexArray, ii + 1, y1);
+  set(vertexArray, ii + 2, 0.0);
+  set(vertexArray, ii + 3, 0.0);
+  set(vertexArray, ii + 4, 0.0);
+  set(vertexArray, ii + 5, 0.0);
+  set(vertexArray, ii + 6, fsubx +. fsubw);
+  set(vertexArray, ii + 7, fsuby +. fsubh);
+  set(vertexArray, ii + 8, x2);
+  set(vertexArray, ii + 9, y2);
+  set(vertexArray, ii + 10, 0.0);
+  set(vertexArray, ii + 11, 0.0);
+  set(vertexArray, ii + 12, 0.0);
+  set(vertexArray, ii + 13, 0.0);
+  set(vertexArray, ii + 14, fsubx);
+  set(vertexArray, ii + 15, fsuby +. fsubh);
+  set(vertexArray, ii + 16, x3);
+  set(vertexArray, ii + 17, y3);
+  set(vertexArray, ii + 18, 0.0);
+  set(vertexArray, ii + 19, 0.0);
+  set(vertexArray, ii + 20, 0.0);
+  set(vertexArray, ii + 21, 0.0);
+  set(vertexArray, ii + 22, fsubx +. fsubw);
+  set(vertexArray, ii + 23, fsuby);
+  set(vertexArray, ii + 24, x4);
+  set(vertexArray, ii + 25, y4);
+  set(vertexArray, ii + 26, 0.0);
+  set(vertexArray, ii + 27, 0.0);
+  set(vertexArray, ii + 28, 0.0);
+  set(vertexArray, ii + 29, 0.0);
+  set(vertexArray, ii + 30, fsubx);
+  set(vertexArray, ii + 31, fsuby);
   let jj = env.batch.elementPtr;
   let elementArray = env.batch.elementArray;
-  set elementArray jj (ii / vertexSize);
-  set elementArray (jj + 1) (ii / vertexSize + 1);
-  set elementArray (jj + 2) (ii / vertexSize + 2);
-  set elementArray (jj + 3) (ii / vertexSize + 1);
-  set elementArray (jj + 4) (ii / vertexSize + 2);
-  set elementArray (jj + 5) (ii / vertexSize + 3);
+  set(elementArray, jj, ii / vertexSize);
+  set(elementArray, jj + 1, ii / vertexSize + 1);
+  set(elementArray, jj + 2, ii / vertexSize + 2);
+  set(elementArray, jj + 3, ii / vertexSize + 1);
+  set(elementArray, jj + 4, ii / vertexSize + 2);
+  set(elementArray, jj + 5, ii / vertexSize + 3);
   env.batch.vertexPtr = ii + 4 * vertexSize;
   env.batch.elementPtr = jj + 6;
-  env.batch.currTex = Some textureBuffer
+  env.batch.currTex = Some(textureBuffer)
 };
 
-let drawImageWithMatrix
-    image
-    ::x
-    ::y
-    ::width
-    ::height
-    ::subx
-    ::suby
-    ::subw
-    ::subh
-    env => {
-      let transform = Matrix.matptmul env.matrix;
-      let p1 = transform (float_of_int @@ x + width, float_of_int @@ y + height);
-      let p2 = transform (float_of_int x, float_of_int @@ y + height);
-      let p3 = transform (float_of_int @@ x + width, float_of_int y);
-      let p4 = transform (float_of_int x, float_of_int y);
-      drawImage image ::p1 ::p2 ::p3 ::p4 ::subx ::suby ::subw ::subh env
-    };
+let drawImageWithMatrix =
+    (image, ~x, ~y, ~width, ~height, ~subx, ~suby, ~subw, ~subh, env) => {
+  let transform = Matrix.matptmul(env.matrix);
+  let p1 = transform((float_of_int @@ x + width, float_of_int @@ y + height));
+  let p2 = transform((float_of_int(x), float_of_int @@ y + height));
+  let p3 = transform((float_of_int @@ x + width, float_of_int(y)));
+  let p4 = transform((float_of_int(x), float_of_int(y)));
+  drawImage(image, ~p1, ~p2, ~p3, ~p4, ~subx, ~suby, ~subw, ~subh, env)
+};
 
-/** Recomputes matrices while resetting size of window */
-let resetSize env width height => {
+
+/*** Recomputes matrices while resetting size of window */
+let resetSize = (env, width, height) => {
   env.size.width = width;
   env.size.height = height;
   let (pixelWidth, pixelHeight) =
-    Gl.Window.(getPixelWidth env.window, getPixelHeight env.window);
-  Gl.viewport context::env.gl x::0 y::0 width::pixelWidth height::pixelHeight;
-  Gl.clearColor context::env.gl r::0. g::0. b::0. a::1.;
-  Gl.Mat4.ortho
-    out::env.camera.projectionMatrix
-    left::0.
-    right::(float_of_int width)
-    bottom::(float_of_int height)
-    top::0.
-    near::0.
-    far::1.;
+    Gl.Window.(getPixelWidth(env.window), getPixelHeight(env.window));
+  Gl.viewport(
+    ~context=env.gl,
+    ~x=0,
+    ~y=0,
+    ~width=pixelWidth,
+    ~height=pixelHeight
+  );
+  Gl.clearColor(~context=env.gl, ~r=0., ~g=0., ~b=0., ~a=1.);
+  Gl.Mat4.ortho(
+    ~out=env.camera.projectionMatrix,
+    ~left=0.,
+    ~right=float_of_int(width),
+    ~bottom=float_of_int(height),
+    ~top=0.,
+    ~near=0.,
+    ~far=1.
+  );
 
-  /** Tell OpenGL about what the uniform called `pMatrixUniform` is, here it's the projectionMatrix. **/
-  Gl.uniformMatrix4fv
-    context::env.gl
-    location::env.pMatrixUniform
-    value::env.camera.projectionMatrix
+  /*** Tell OpenGL about what the uniform called `pMatrixUniform` is, here it's the projectionMatrix. **/
+  Gl.uniformMatrix4fv(
+    ~context=env.gl,
+    ~location=env.pMatrixUniform,
+    ~value=env.camera.projectionMatrix
+  )
 };

--- a/src/Reprocessing_Matrix.re
+++ b/src/Reprocessing_Matrix.re
@@ -1,83 +1,77 @@
 let identity = [|1., 0., 0., 0., 1., 0., 0., 0., 1.|];
 
-let createIdentity () => [|1., 0., 0., 0., 1., 0., 0., 0., 1.|];
+let createIdentity = () => [|1., 0., 0., 0., 1., 0., 0., 0., 1.|];
 
-let createTranslation dx dy => [|1., 0., dx, 0., 1., dy, 0., 0., 1.|];
+let createTranslation = (dx, dy) => [|1., 0., dx, 0., 1., dy, 0., 0., 1.|];
 
-let createRotation theta => [|
-  cos theta,
-  -. sin theta,
+let createRotation = (theta) => [|
+  cos(theta),
+  -. sin(theta),
   0.,
-  sin theta,
-  cos theta,
+  sin(theta),
+  cos(theta),
   0.,
   0.,
   0.,
   1.
 |];
 
-let createScaling sx sy => [|sx, 0., 0., 0., sy, 0., 0., 0., 1.|];
+let createScaling = (sx, sy) => [|sx, 0., 0., 0., sy, 0., 0., 0., 1.|];
 
-let createShearing sx sy => [|1., sx, 0., sy, 1., 0., 0., 0., 1.|];
+let createShearing = (sx, sy) => [|1., sx, 0., sy, 1., 0., 0., 0., 1.|];
 
-let copyInto ::src ::dst => {
-  dst.(0) = src.(0);
-  dst.(1) = src.(1);
-  dst.(2) = src.(2);
-  dst.(3) = src.(3);
-  dst.(4) = src.(4);
-  dst.(5) = src.(5);
-  dst.(6) = src.(6);
-  dst.(7) = src.(7);
-  dst.(8) = src.(8)
+let copyInto = (~src, ~dst) => {
+  dst[0] = src[0];
+  dst[1] = src[1];
+  dst[2] = src[2];
+  dst[3] = src[3];
+  dst[4] = src[4];
+  dst[5] = src[5];
+  dst[6] = src[6];
+  dst[7] = src[7];
+  dst[8] = src[8]
 };
 
 
-/**
+/***
  [0 1 2]   [a b c]   [a0 + d1 + g2, b0 + e1 + h2, c0 + f1 + i2]
  [3 4 5] * [d e f] = [a3 + d4 + g5, b3 + e4 + h5, c3 + f4 + i5]
  [6 7 8]   [g h i]   [a6 + d7 + g8, b6 + e7 + h8, c6 + f7 + i8]
  */
-let matmatmul (mat1: array float) (mat2: array float) =>
+let matmatmul = (mat1: array(float), mat2: array(float)) =>
   switch (mat1, mat2) {
-  | (
-      [|m0, m1, m2, m3, m4, m5, m6, m7, m8|],
-      [|ma, mb, mc, md, me, mf, mg, mh, mi|]
-    ) =>
-    mat1.(0) = ma *. m0 +. md *. m1 +. mg *. m2;
-    mat1.(1) = mb *. m0 +. me *. m1 +. mh *. m2;
-    mat1.(2) = mc *. m0 +. mf *. m1 +. mi *. m2;
-    mat1.(3) = ma *. m3 +. md *. m4 +. mg *. m5;
-    mat1.(4) = mb *. m3 +. me *. m4 +. mh *. m5;
-    mat1.(5) = mc *. m3 +. mf *. m4 +. mi *. m5;
-    mat1.(6) = ma *. m6 +. md *. m7 +. mg *. m8;
-    mat1.(7) = mb *. m6 +. me *. m7 +. mh *. m8;
-    mat1.(8) = mc *. m6 +. mf *. m7 +. mi *. m8
+  | ([|m0, m1, m2, m3, m4, m5, m6, m7, m8|], [|ma, mb, mc, md, me, mf, mg, mh, mi|]) =>
+    mat1[0] = ma *. m0 +. md *. m1 +. mg *. m2;
+    mat1[1] = mb *. m0 +. me *. m1 +. mh *. m2;
+    mat1[2] = mc *. m0 +. mf *. m1 +. mi *. m2;
+    mat1[3] = ma *. m3 +. md *. m4 +. mg *. m5;
+    mat1[4] = mb *. m3 +. me *. m4 +. mh *. m5;
+    mat1[5] = mc *. m3 +. mf *. m4 +. mi *. m5;
+    mat1[6] = ma *. m6 +. md *. m7 +. mg *. m8;
+    mat1[7] = mb *. m6 +. me *. m7 +. mh *. m8;
+    mat1[8] = mc *. m6 +. mf *. m7 +. mi *. m8
   | _ => assert false
   };
 
 
-/**
+/***
  [0 1 2]   [a]   [a0 + b1 + c2]
  [3 4 5] * [b] = [a3 + b4 + c5]
  [6 7 8]   [c]   [a6 + b7 + c8]
  */
-let matvecmul m v => {
-  let a = v.(0);
-  let b = v.(1);
-  let c = v.(2);
-  v.(0) = a *. m.(0) +. b *. m.(1) +. c *. m.(2);
-  v.(1) = a *. m.(3) +. b *. m.(4) +. c *. m.(5);
-  v.(2) = a *. m.(6) +. b *. m.(7) +. c *. m.(8)
+let matvecmul = (m, v) => {
+  let a = v[0];
+  let b = v[1];
+  let c = v[2];
+  v[0] = a *. m[0] +. b *. m[1] +. c *. m[2];
+  v[1] = a *. m[3] +. b *. m[4] +. c *. m[5];
+  v[2] = a *. m[6] +. b *. m[7] +. c *. m[8]
 };
 
 
-/**
+/***
  [0 1 2]   [x]   [x0 + y1 + 2]
  [3 4 5] * [y] = [x3 + y4 + 5]
  [6 7 8]   [1]   [ who cares ]
  */
-let matptmul m (x, y) => (
-  x *. m.(0) +. y *. m.(1) +. m.(2),
-  x *. m.(3) +. y *. m.(4) +. m.(5)
-);
+let matptmul = (m, (x, y)) => (x *. m[0] +. y *. m[1] +. m[2], x *. m[3] +. y *. m[4] +. m[5]);

--- a/src/Reprocessing_Utils.re
+++ b/src/Reprocessing_Utils.re
@@ -2,19 +2,19 @@ open Reprocessing_Common;
 
 let foi = float_of_int;
 
-let lookup_table: ref (array int) = ref [||];
+let lookup_table: ref(array(int)) = ref([||]);
 
 /*Calculation Functions*/
-let round i => floor (i +. 0.5);
+let round = (i) => floor(i +. 0.5);
 
-let sq x => x * x;
+let sq = (x) => x * x;
 
-let rec pow ::base ::exp =>
+let rec pow = (~base, ~exp) =>
   switch exp {
   | 0 => 1
   | 1 => base
   | n =>
-    let b = pow ::base exp::(n / 2);
+    let b = pow(~base, ~exp=n / 2);
     b
     * b
     * (
@@ -26,73 +26,72 @@ let rec pow ::base ::exp =>
     )
   };
 
-let constrain ::amt ::low ::high => max (min amt high) low;
+let constrain = (~amt, ~low, ~high) => max(min(amt, high), low);
 
-let remapf ::value ::low1 ::high1 ::low2 ::high2 =>
+let remapf = (~value, ~low1, ~high1, ~low2, ~high2) =>
   low2 +. (high2 -. low2) *. ((value -. low1) /. (high1 -. low1));
 
-let remap ::value ::low1 ::high1 ::low2 ::high2 =>
-  int_of_float (
-    remapf
-      value::(foi value)
-      low1::(foi low1)
-      high1::(foi high1)
-      low2::(foi low2)
-      high2::(foi high2)
+let remap = (~value, ~low1, ~high1, ~low2, ~high2) =>
+  int_of_float(
+    remapf(
+      ~value=foi(value),
+      ~low1=foi(low1),
+      ~high1=foi(high1),
+      ~low2=foi(low2),
+      ~high2=foi(high2)
+    )
   );
 
-let norm ::value ::low ::high =>
-  remapf ::value low1::low high1::high low2::0. high2::1.;
+let norm = (~value, ~low, ~high) => remapf(~value, ~low1=low, ~high1=high, ~low2=0., ~high2=1.);
 
-let randomf ::min ::max => Random.float (max -. min) +. min;
+let randomf = (~min, ~max) => Random.float(max -. min) +. min;
 
-let random ::min ::max => Random.int (max - min) + min;
+let random = (~min, ~max) => Random.int(max - min) + min;
 
-let randomSeed seed => Random.init seed;
+let randomSeed = (seed) => Random.init(seed);
 
-let randomGaussian () => {
-  let u1 = ref 0.0;
-  let u2 = ref 0.0;
-  while (!u1 <= min_float) {
-    u1 := Random.float 1.0;
-    u2 := Random.float 1.0
+let randomGaussian = () => {
+  let u1 = ref(0.0);
+  let u2 = ref(0.0);
+  while (u1^ <= min_float) {
+    u1 := Random.float(1.0);
+    u2 := Random.float(1.0)
   };
-  sqrt ((-2.0) *. log !u1) *. cos (Reprocessing_Constants.two_pi *. !u2)
+  sqrt((-2.0) *. log(u1^)) *. cos(Reprocessing_Constants.two_pi *. u2^)
 };
 
-let lerpf ::low ::high => remapf low1::0. high1::1. low2::low high2::high;
+let lerpf = (~low, ~high) => remapf(~low1=0., ~high1=1., ~low2=low, ~high2=high);
 
-let lerp ::low ::high ::value =>
-  int_of_float (lerpf low::(foi low) high::(foi high) ::value);
+let lerp = (~low, ~high, ~value) => int_of_float(lerpf(~low=foi(low), ~high=foi(high), ~value));
 
-let distf p1::(x1: float, y1: float) p2::(x2: float, y2: float) => {
+let distf = (~p1 as (x1: float, y1: float), ~p2 as (x2: float, y2: float)) => {
   let dx = x2 -. x1;
   let dy = y2 -. y1;
-  sqrt (dx *. dx +. dy *. dy)
+  sqrt(dx *. dx +. dy *. dy)
 };
 
-let dist p1::(x1, y1) p2::(x2, y2) =>
-  distf p1::(foi x1, foi y1) p2::(foi x2, foi y2);
+let dist = (~p1 as (x1, y1), ~p2 as (x2, y2)) =>
+  distf(~p1=(foi(x1), foi(y1)), ~p2=(foi(x2), foi(y2)));
 
-let magf vec => distf p1::(0., 0.) p2::vec;
+let magf = (vec) => distf(~p1=(0., 0.), ~p2=vec);
 
-let mag vec => dist p1::(0, 0) p2::vec;
+let mag = (vec) => dist(~p1=(0, 0), ~p2=vec);
 
-let lerpColor ::low ::high ::value => {
-  r: lerpf low::low.r high::high.r ::value,
-  g: lerpf low::low.g high::high.g ::value,
-  b: lerpf low::low.b high::high.b ::value,
-  a: lerpf low::low.a high::high.a ::value
+let lerpColor = (~low, ~high, ~value) => {
+  r: lerpf(~low=low.r, ~high=high.r, ~value),
+  g: lerpf(~low=low.g, ~high=high.g, ~value),
+  b: lerpf(~low=low.b, ~high=high.b, ~value),
+  a: lerpf(~low=low.a, ~high=high.a, ~value)
 };
 
-let degrees x => 180.0 /. Reprocessing_Constants.pi *. x;
+let degrees = (x) => 180.0 /. Reprocessing_Constants.pi *. x;
 
-let radians x => Reprocessing_Constants.pi /. 180.0 *. x;
+let radians = (x) => Reprocessing_Constants.pi /. 180.0 *. x;
 
-let noise x y z => {
-  let p = !lookup_table;
-  let fade t => t *. t *. t *. (t *. (t *. 6.0 -. 15.0) +. 10.0);
-  let grad hash x y z =>
+let noise = (x, y, z) => {
+  let p = lookup_table^;
+  let fade = (t) => t *. t *. t *. (t *. (t *. 6.0 -. 15.0) +. 10.0);
+  let grad = (hash, x, y, z) =>
     switch (hash land 15) {
     | 0 => x +. y
     | 1 => -. x +. y
@@ -112,109 +111,89 @@ let noise x y z => {
     | 15 => -. y -. z
     | _ => 0.0
     };
-  let xi = int_of_float x land 255;
-  let yi = int_of_float y land 255;
-  let zi = int_of_float z land 255;
-  let xf = x -. floor x;
-  let yf = y -. floor y;
-  let zf = z -. floor z;
-  let u = fade xf;
-  let v = fade yf;
-  let w = fade zf;
-  let aaa = p.(p.(p.(xi) + yi) + zi);
-  let aba = p.(p.(p.(xi) + (yi + 1)) + zi);
-  let aab = p.(p.(p.(xi) + yi) + (zi + 1));
-  let abb = p.(p.(p.(xi) + (yi + 1)) + (zi + 1));
-  let baa = p.(p.(p.(xi + 1) + yi) + zi);
-  let bba = p.(p.(p.(xi + 1) + (yi + 1)) + zi);
-  let bab = p.(p.(p.(xi + 1) + yi) + (zi + 1));
-  let bbb = p.(p.(p.(xi + 1) + (yi + 1)) + (zi + 1));
-  let x1 =
-    lerpf low::(grad aaa xf yf zf) high::(grad baa (xf -. 1.0) yf zf) value::u;
+  let xi = int_of_float(x) land 255;
+  let yi = int_of_float(y) land 255;
+  let zi = int_of_float(z) land 255;
+  let xf = x -. floor(x);
+  let yf = y -. floor(y);
+  let zf = z -. floor(z);
+  let u = fade(xf);
+  let v = fade(yf);
+  let w = fade(zf);
+  let aaa = p[p[p[xi] + yi] + zi];
+  let aba = p[p[p[xi] + (yi + 1)] + zi];
+  let aab = p[p[p[xi] + yi] + (zi + 1)];
+  let abb = p[p[p[xi] + (yi + 1)] + (zi + 1)];
+  let baa = p[p[p[xi + 1] + yi] + zi];
+  let bba = p[p[p[xi + 1] + (yi + 1)] + zi];
+  let bab = p[p[p[xi + 1] + yi] + (zi + 1)];
+  let bbb = p[p[p[xi + 1] + (yi + 1)] + (zi + 1)];
+  let x1 = lerpf(~low=grad(aaa, xf, yf, zf), ~high=grad(baa, xf -. 1.0, yf, zf), ~value=u);
   let x2 =
-    lerpf
-      low::(grad aba xf (yf -. 1.0) zf)
-      high::(grad bba (xf -. 1.0) (yf -. 1.0) zf)
-      value::u;
-  let y1 = lerpf low::x1 high::x2 value::v;
+    lerpf(~low=grad(aba, xf, yf -. 1.0, zf), ~high=grad(bba, xf -. 1.0, yf -. 1.0, zf), ~value=u);
+  let y1 = lerpf(~low=x1, ~high=x2, ~value=v);
   let x1 =
-    lerpf
-      low::(grad aab xf yf (zf -. 1.0))
-      high::(grad bab (xf -. 1.0) yf (zf -. 1.0))
-      value::u;
+    lerpf(~low=grad(aab, xf, yf, zf -. 1.0), ~high=grad(bab, xf -. 1.0, yf, zf -. 1.0), ~value=u);
   let x2 =
-    lerpf
-      low::(grad abb xf (yf -. 1.0) (zf -. 1.0))
-      high::(grad bbb (xf -. 1.0) (yf -. 1.0) (zf -. 1.0))
-      value::u;
-  let y2 = lerpf low::x1 high::x2 value::v;
-  (lerpf low::y1 high::y2 value::w +. 1.0) /. 2.0
+    lerpf(
+      ~low=grad(abb, xf, yf -. 1.0, zf -. 1.0),
+      ~high=grad(bbb, xf -. 1.0, yf -. 1.0, zf -. 1.0),
+      ~value=u
+    );
+  let y2 = lerpf(~low=x1, ~high=x2, ~value=v);
+  (lerpf(~low=y1, ~high=y2, ~value=w) +. 1.0) /. 2.0
 };
 
-let shuffle array => {
-  let array = Array.copy array;
-  let length = Array.length array;
-  for i in 0 to (256 - 1) {
-    let j = Random.int (length - i);
-    let tmp = array.(i);
-    array.(i) = array.(i + j);
-    array.(i + j) = tmp
+let shuffle = (array) => {
+  let array = Array.copy(array);
+  let length = Array.length(array);
+  for (i in 0 to 256 - 1) {
+    let j = Random.int(length - i);
+    let tmp = array[i];
+    array[i] = array[i + j];
+    array[i + j] = tmp
   };
   array
 };
 
-let noiseSeed seed => {
-  let state = Random.get_state ();
-  Random.init seed;
-  let array = Array.make 256 0;
-  let array = Array.mapi (fun i _ => i) array;
-  let array = shuffle array;
-  let double_array = Array.append array array;
+let noiseSeed = (seed) => {
+  let state = Random.get_state();
+  Random.init(seed);
+  let array = Array.make(256, 0);
+  let array = Array.mapi((i, _) => i, array);
+  let array = shuffle(array);
+  let double_array = Array.append(array, array);
   lookup_table := double_array;
-  Random.set_state state
+  Random.set_state(state)
 };
 
 let split = Reprocessing_Common.split;
 
-let color ::r ::g ::b ::a :colorT => {
-  r: foi r /. 255.,
-  g: foi g /. 255.,
-  b: foi b /. 255.,
-  a: foi a /. 255.
+let color = (~r, ~g, ~b, ~a) : colorT => {
+  r: foi(r) /. 255.,
+  g: foi(g) /. 255.,
+  b: foi(b) /. 255.,
+  a: foi(a) /. 255.
 };
 
-let colorf ::r ::g ::b ::a :colorT => {r, g, b, a};
+let colorf = (~r, ~g, ~b, ~a) : colorT => {r, g, b, a};
 
-let intersectRectCircle
-    rectPos::(rx, ry)
-    ::rectW
-    ::rectH
-    circlePos::(cx, cy)
-    ::circleRad => {
+let intersectRectCircle =
+    (~rectPos as (rx, ry), ~rectW, ~rectH, ~circlePos as (cx, cy), ~circleRad) => {
   let halfW = rectW /. 2.;
   let halfH = rectH /. 2.;
-  let cdistX = abs_float (cx -. (rx +. halfW));
-  let cdistY = abs_float (cy -. (ry +. halfH));
+  let cdistX = abs_float(cx -. (rx +. halfW));
+  let cdistY = abs_float(cy -. (ry +. halfH));
   if (cdistX > halfW +. circleRad || cdistY > halfH +. circleRad) {
     false
-  } else if (
-    cdistX <= halfW || cdistY <= halfH
-  ) {
+  } else if (cdistX <= halfW || cdistY <= halfH) {
     true
   } else {
-    let cornerDistSq = (cdistX -. halfW) *\* 2. +. (cdistY -. halfH) *\* 2.;
-    cornerDistSq <= circleRad *\* 2.
+    let cornerDistSq = (cdistX -. halfW) ** 2. +. (cdistY -. halfH) ** 2.;
+    cornerDistSq <= circleRad ** 2.
   }
 };
 
-let intersectRectRect
-    rect1Pos::(rx1, ry1)
-    ::rect1W
-    ::rect1H
-    rect2Pos::(rx2, ry2)
-    ::rect2W
-    ::rect2H =>
-  not (
-    rx2 > rx1 +. rect1W ||
-    rx2 +. rect2W < rx1 || ry2 > ry1 +. rect1H || ry2 +. rect2H < ry1
-  );
+let intersectRectRect =
+    (~rect1Pos as (rx1, ry1), ~rect1W, ~rect1H, ~rect2Pos as (rx2, ry2), ~rect2W, ~rect2H) =>
+  ! (rx2 > rx1 +. rect1W || rx2 +. rect2W < rx1 || ry2 > ry1 +. rect1H || ry2 +. rect2H < ry1);

--- a/src/Reprocessing_Utils.rei
+++ b/src/Reprocessing_Utils.rei
@@ -1,62 +1,50 @@
-/** Creates colors for storing in variables of the color datatype.
+/*** Creates colors for storing in variables of the color datatype.
   *
   * Components should be in the range 0 to 255 (or 0x00 to 0xFF).
  */
-let color:
-  r::int => g::int => b::int => a::int => Reprocessing_Types.Types.colorT;
+let color: (~r: int, ~g: int, ~b: int, ~a: int) => Reprocessing_Types.Types.colorT;
 
 
-/** Creates colors for storing in variables of the color datatype.
+/*** Creates colors for storing in variables of the color datatype.
   *
   * Components should be in the range 0.0 to 1.0.
  */
-let colorf:
-  r::float =>
-  g::float =>
-  b::float =>
-  a::float =>
-  Reprocessing_Types.Types.colorT;
+let colorf: (~r: float, ~g: float, ~b: float, ~a: float) => Reprocessing_Types.Types.colorT;
 
 
-/** Calculates the integer closest to the input. For example,
+/*** Calculates the integer closest to the input. For example,
   * `round 133.8` returns the value 134.
  */
 let round: float => float;
 
 
-/** Squares a number (multiplies a number by itself). The result is always a
+/*** Squares a number (multiplies a number by itself). The result is always a
   * positive number, as multiplying two negative numbers always yields a
   * positive result.
  */
 let sq: int => int;
 
 
-/** Facilitates exponential expressions. The pow() function is an efficient
+/*** Facilitates exponential expressions. The pow() function is an efficient
   * way of multiplying numbers by themselves (or their reciprocals) in large
   * quantities.
  */
-let pow: base::int => exp::int => int;
+let pow: (~base: int, ~exp: int) => int;
 
 
-/** Constrains a value to not exceed a maximum and minimum value. */
-let constrain: amt::'a => low::'a => high::'a => 'a;
+/*** Constrains a value to not exceed a maximum and minimum value. */
+let constrain: (~amt: 'a, ~low: 'a, ~high: 'a) => 'a;
 
 
-/** Re-maps a number from one range to another.
+/*** Re-maps a number from one range to another.
   * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
   * would give 15.
   * Useful for scaling values.
  */
-let remapf:
-  value::float =>
-  low1::float =>
-  high1::float =>
-  low2::float =>
-  high2::float =>
-  float;
+let remapf: (~value: float, ~low1: float, ~high1: float, ~low2: float, ~high2: float) => float;
 
 
-/** Re-maps a number from one range to another.
+/*** Re-maps a number from one range to another.
   * i.e. `remapf value::5. start1::0. stop1::10. start2::10. stop2::20.`
   * would give 15.
   * Useful for scaling values.
@@ -64,34 +52,33 @@ let remapf:
   * This is the same as `remapf`, but converts all its integer arguments to floats
   * as a convenience.
  */
-let remap:
-  value::int => low1::int => high1::int => low2::int => high2::int => int;
+let remap: (~value: int, ~low1: int, ~high1: int, ~low2: int, ~high2: int) => int;
 
 
-/** Normalizes a number from another range into a value between 0 and 1.
+/*** Normalizes a number from another range into a value between 0 and 1.
   * Identical to `remap ::value ::low ::high 0. 1.`
  */
-let norm: value::float => low::float => high::float => float;
+let norm: (~value: float, ~low: float, ~high: float) => float;
 
 
-/** Generates random numbers. Each time the `randomf` function is called, it
+/*** Generates random numbers. Each time the `randomf` function is called, it
   * returns an unexpected value within the specified range. The top number is
   * not included.
  */
-let randomf: min::float => max::float => float;
+let randomf: (~min: float, ~max: float) => float;
 
 
-/** Generates random numbers. Each time the `random` function is called, it
+/*** Generates random numbers. Each time the `random` function is called, it
   * returns an unexpected value within the specified range. The top number is
   * not included.
   *
   * This is the same as `randomf`, but converts all its integer arguments to floats
   * as a convenience.
  */
-let random: min::int => max::int => int;
+let random: (~min: int, ~max: int) => int;
 
 
-/** Sets the seed value for `random` and `randomf`. By default, `random`
+/*** Sets the seed value for `random` and `randomf`. By default, `random`
   * produces different results each time the program is run. Set the
   * seed parameter to a constant to return the same pseudo-random
   * numbers each time the software is run.
@@ -100,7 +87,7 @@ let random: min::int => max::int => int;
 let randomSeed: int => unit;
 
 
-/** Returns a float from a random series of numbers having a mean of 0 and
+/*** Returns a float from a random series of numbers having a mean of 0 and
   * standard deviation of 1. Each time the `randomGaussian` function is called,
   * it returns a number fitting a Gaussian, or normal, distribution. There is
   * theoretically no minimum or maximum value that `randomGaussian might
@@ -111,16 +98,16 @@ let randomSeed: int => unit;
 let randomGaussian: unit => float;
 
 
-/** Calculates a number between two numbers at a specific increment. The
+/*** Calculates a number between two numbers at a specific increment. The
   * amt parameter is the amount to interpolate between the two values where 0.0
   * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
   * in between, etc. The lerp function is convenient for creating motion along a
   * straight path and for drawing dotted lines.
  */
-let lerpf: low::float => high::float => value::float => float;
+let lerpf: (~low: float, ~high: float, ~value: float) => float;
 
 
-/** Calculates a number between two numbers at a specific increment. The
+/*** Calculates a number between two numbers at a specific increment. The
   * amt parameter is the amount to interpolate between the two values where 0.0
   * equal to the `low` point, 0.1 is very near the `low` point, 0.5 is half-way
   * in between, etc. The lerp function is convenient for creating motion along a
@@ -129,37 +116,35 @@ let lerpf: low::float => high::float => value::float => float;
   * This is the same as `lerpf`, but converts all its integer arguments to floats
   * as a convenience.
  */
-let lerp: low::int => high::int => value::float => int;
+let lerp: (~low: int, ~high: int, ~value: float) => int;
 
 let lerpColor:
-  low::Reprocessing_Types.Types.colorT =>
-  high::Reprocessing_Types.Types.colorT =>
-  value::float =>
+  (~low: Reprocessing_Types.Types.colorT, ~high: Reprocessing_Types.Types.colorT, ~value: float) =>
   Reprocessing_Types.Types.colorT;
 
 
-/** Calculates the distance between two points. */
-let distf: p1::(float, float) => p2::(float, float) => float;
+/*** Calculates the distance between two points. */
+let distf: (~p1: (float, float), ~p2: (float, float)) => float;
 
 
-/** Calculates the distance between two points.
+/*** Calculates the distance between two points.
   *
   * This is the same as `distf`, but converts all its integer arguments to floats
   * as a convenience.
  */
-let dist: p1::(int, int) => p2::(int, int) => float;
+let dist: (~p1: (int, int), ~p2: (int, int)) => float;
 
 
-/** Calculates the magnitude (or length) of a vector. A vector is a direction
+/*** Calculates the magnitude (or length) of a vector. A vector is a direction
   * in space commonly used in computer graphics and linear algebra. Because it
   * has no "start" position, the magnitude of a vector can be thought of as the
   * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
   * shortcut for writing `dist (0, 0) (x, y)`.
  */
-let magf: (float, float) => float;
+let magf: ((float, float)) => float;
 
 
-/** Calculates the magnitude (or length) of a vector. A vector is a direction
+/*** Calculates the magnitude (or length) of a vector. A vector is a direction
   * in space commonly used in computer graphics and linear algebra. Because it
   * has no "start" position, the magnitude of a vector can be thought of as the
   * distance from the coordinate 0,0 to its x,y value. Therefore, `mag` is a
@@ -168,10 +153,10 @@ let magf: (float, float) => float;
   * This is the same as `magf`, but converts all its integer arguments to floats
   * as a convenience.
  */
-let mag: (int, int) => float;
+let mag: ((int, int)) => float;
 
 
-/** Converts a radian measurement to its corresponding value in degrees.
+/*** Converts a radian measurement to its corresponding value in degrees.
   * Radians and degrees are two ways of measuring the same thing. There are 360
   * degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 =
   * 1.5707964. All trigonometric functions require their parameters to be
@@ -180,7 +165,7 @@ let mag: (int, int) => float;
 let degrees: float => float;
 
 
-/** Converts a degree measurement to its corresponding value in radians.
+/*** Converts a degree measurement to its corresponding value in radians.
   * Radians and degrees are two ways of measuring the same thing. There are 360
   * degrees in a circle and 2*PI radians in a circle. For example, 90° = PI/2 =
   * 1.5707964. All trigonometric functions require their parameters to be
@@ -189,7 +174,7 @@ let degrees: float => float;
 let radians: float => float;
 
 
-/** Returns the Perlin noise value at specified coordinates. Perlin noise is a
+/*** Returns the Perlin noise value at specified coordinates. Perlin noise is a
   * random sequence generator producing a more natural, harmonic succession of
   * numbers than that of the standard random() function. It was developed by Ken
   * Perlin in the 1980s and has been used in graphical applications to generate
@@ -212,46 +197,52 @@ let radians: float => float;
   * successive coordinates is important (such as when using noise() within a loop).
   * As a general rule, the smaller the difference between coordinates, the smoother the resulting noise sequence. Steps of 0.005-0.03 work best for most applications, but this will differ depending on use.
  */
-let noise: float => float => float => float;
+let noise: (float, float, float) => float;
 
 
-/** Sets the seed value for `noise`.  This will also affect the
+/*** Sets the seed value for `noise`.  This will also affect the
   * seed value for `random` and `randomf`.
  */
 let noiseSeed: int => unit;
 
 
-/** The `split` function breaks a string into pieces using a character
+/*** The `split` function breaks a string into pieces using a character
   * as the delimiter. The sep parameter specifies the character
   * that mark the boundaries between each piece. A list is returned
   * that contains each of the pieces.
  */
-let split: string => sep::char => list string;
+let split: (string, ~sep: char) => list(string);
 
-/** Determines if there is an intersection between a rectangle and a circle.
-  * rectPos refers to the top left of the rect and circlePos to the center of
-  * the circle. rectW and rectH are the width and height of the rectangle and
-  * circleRad is the radius of the circle.
-  * Returns true if the two shapes overlap.
-  */
+
+/*** Determines if there is an intersection between a rectangle and a circle.
+ * rectPos refers to the top left of the rect and circlePos to the center of
+ * the circle. rectW and rectH are the width and height of the rectangle and
+ * circleRad is the radius of the circle.
+ * Returns true if the two shapes overlap.
+ */
 let intersectRectCircle:
-  rectPos::(float, float) =>
-  rectW::float =>
-  rectH::float =>
-  circlePos::(float, float) =>
-  circleRad::float =>
+  (
+    ~rectPos: (float, float),
+    ~rectW: float,
+    ~rectH: float,
+    ~circlePos: (float, float),
+    ~circleRad: float
+  ) =>
   bool;
 
-/** Determines if there is an intersection between two axis-aligned rectangles.
-  * rect1Pos and rect2Pos refer to the top left of the rectangles.
-  * rectW and rectH are the width and height of the rectangle.
-  * Returns true if the two shapes overlap.
-  */
+
+/*** Determines if there is an intersection between two axis-aligned rectangles.
+ * rect1Pos and rect2Pos refer to the top left of the rectangles.
+ * rectW and rectH are the width and height of the rectangle.
+ * Returns true if the two shapes overlap.
+ */
 let intersectRectRect:
-  rect1Pos::(float, float) =>
-  rect1W::float =>
-  rect1H::float =>
-  rect2Pos::(float, float) =>
-  rect2W::float =>
-  rect2H::float =>
+  (
+    ~rect1Pos: (float, float),
+    ~rect1W: float,
+    ~rect1H: float,
+    ~rect2Pos: (float, float),
+    ~rect2W: float,
+    ~rect2H: float
+  ) =>
   bool;

--- a/webenv-artifacts/Reprocessing_ClientWrapper.re
+++ b/webenv-artifacts/Reprocessing_ClientWrapper.re
@@ -1,13 +1,16 @@
 open Reasongl;
 
-external removeFromDOM : 'a => unit = "remove" [@@bs.send];
-external setID : 'a => string => unit = "id" [@@bs.set];
-external appendChild : 'a => 'b => unit = "appendChild" [@@bs.send];
-let init ::argv => {
-  removeFromDOM (Document.getElementById "main-canvas");
-  let canvas = createElement "canvas";
-  setBackgroundColor (getStyle canvas) "black";
-  setID canvas "main-canvas";
-  appendChild (Document.getElementById "canvas-wrapper") canvas;
+[@bs.send] external removeFromDOM : 'a => unit = "remove";
+
+[@bs.set] external setID : ('a, string) => unit = "id";
+
+[@bs.send] external appendChild : ('a, 'b) => unit = "appendChild";
+
+let init = (~argv) => {
+  removeFromDOM(Document.getElementById("main-canvas"));
+  let canvas = createElement("canvas");
+  setBackgroundColor(getStyle(canvas), "black");
+  setID(canvas, "main-canvas");
+  appendChild(Document.getElementById("canvas-wrapper"), canvas);
   canvas
 };

--- a/webenv-artifacts/Reprocessing_Ext.re
+++ b/webenv-artifacts/Reprocessing_Ext.re
@@ -12,7 +12,7 @@ module Reprocessing = {
   type imageT;
   type fontT;
 
-  /** Contains types for events. */
+  /*** Contains types for events. */
   module Events = {
     type buttonStateT =
       | LeftButton
@@ -88,288 +88,250 @@ module Reprocessing = {
       | CapsLock
       | Backtick
       | Nothing;
-    external keycodeMap : int => keycodeT =
-      "window.reprocessing.Events.keycodeMap" [@@bs.val];
+    [@bs.val] external keycodeMap : int => keycodeT = "window.reprocessing.Events.keycodeMap";
   };
   module Draw = {
-    external background : colorT => glEnvT => unit =
-       "window.reprocessing.Draw.background" [@@bs.val];
-    external translate : x::float => y::float => glEnvT => unit =
-       "window.reprocessing.Draw.translate" [@@bs.val];
-    external rotate : float => glEnvT => unit =
-       "window.reprocessing.Draw.rotate" [@@bs.val];
-    external fill : colorT => glEnvT => unit =
-       "window.reprocessing.Draw.fill" [@@bs.val];
-    external noFill : glEnvT => unit =
-       "window.reprocessing.Draw.noFill" [@@bs.val];
-    external stroke : colorT => glEnvT => unit =
-       "window.reprocessing.Draw.stroke" [@@bs.val];
-    external noStroke : glEnvT => unit =
-       "window.reprocessing.Draw.noStroke" [@@bs.val];
-    external strokeWeight : int => glEnvT => unit =
-       "window.reprocessing.Draw.strokeWeight" [@@bs.val];
-    external strokeCap : strokeCapT => glEnvT => unit =
-       "window.reprocessing.Draw.strokeCap" [@@bs.val];
-    external pushStyle : glEnvT => unit =
-       "window.reprocessing.Draw.pushStyle" [@@bs.val];
-    external popStyle : glEnvT => unit =
-       "window.reprocessing.Draw.popStyle" [@@bs.val];
-    external loadImage : filename::string => glEnvT => imageT =
-       "window.reprocessing.Draw.loadImage" [@@bs.val];
+    [@bs.val] external background : (colorT, glEnvT) => unit =
+      "window.reprocessing.Draw.background";
+    [@bs.val] external translate : (~x: float, ~y: float, glEnvT) => unit =
+      "window.reprocessing.Draw.translate";
+    [@bs.val] external rotate : (float, glEnvT) => unit = "window.reprocessing.Draw.rotate";
+    [@bs.val] external fill : (colorT, glEnvT) => unit = "window.reprocessing.Draw.fill";
+    [@bs.val] external noFill : glEnvT => unit = "window.reprocessing.Draw.noFill";
+    [@bs.val] external stroke : (colorT, glEnvT) => unit = "window.reprocessing.Draw.stroke";
+    [@bs.val] external noStroke : glEnvT => unit = "window.reprocessing.Draw.noStroke";
+    [@bs.val] external strokeWeight : (int, glEnvT) => unit =
+      "window.reprocessing.Draw.strokeWeight";
+    [@bs.val] external strokeCap : (strokeCapT, glEnvT) => unit =
+      "window.reprocessing.Draw.strokeCap";
+    [@bs.val] external pushStyle : glEnvT => unit = "window.reprocessing.Draw.pushStyle";
+    [@bs.val] external popStyle : glEnvT => unit = "window.reprocessing.Draw.popStyle";
+    [@bs.val] external loadImage : (~filename: string, glEnvT) => imageT =
+      "window.reprocessing.Draw.loadImage";
+    [@bs.val]
     external _image :
-      imageT =>
-      pos::(int, int) =>
-      width::option int =>
-      height::option int =>
-      glEnvT =>
-      unit =
-      "window.reprocessing.Draw.image" [@@bs.val];
-    let image img ::pos ::width=? ::height=? env =>
-      _image img ::pos ::width ::height env;
+      (imageT, ~pos: (int, int), ~width: option(int), ~height: option(int), glEnvT) => unit =
+      "window.reprocessing.Draw.image";
+    let image = (img, ~pos, ~width=?, ~height=?, env) => _image(img, ~pos, ~width, ~height, env);
+    [@bs.val]
     external subImage :
-      imageT =>
-      pos::(int, int) =>
-      width::int =>
-      height::int =>
-      texPos::(int, int) =>
-      texWidth::int =>
-      texHeight::int =>
-      glEnvT =>
+      (
+        imageT,
+        ~pos: (int, int),
+        ~width: int,
+        ~height: int,
+        ~texPos: (int, int),
+        ~texWidth: int,
+        ~texHeight: int,
+        glEnvT
+      ) =>
       unit =
-       "window.reprocessing.Draw.subImage" [@@bs.val];
-    external rectf :
-      pos::(float, float) => width::float => height::float => glEnvT => unit =
-       "window.reprocessing.Draw.rectf" [@@bs.val];
-    external rect :
-      pos::(int, int) => width::int => height::int => glEnvT => unit =
-       "window.reprocessing.Draw.rect" [@@bs.val];
-    external linef : p1::(float, float) => p2::(float, float) => glEnvT => unit =
-       "window.reprocessing.Draw.linef" [@@bs.val];
-    external line : p1::(int, int) => p2::(int, int) => glEnvT => unit =
-       "window.reprocessing.Draw.line" [@@bs.val];
-    external ellipsef :
-      center::(float, float) => radx::float => rady::float => glEnvT => unit =
-       "window.reprocessing.Draw.ellipsef" [@@bs.val];
-    external ellipse :
-      center::(int, int) => radx::int => rady::int => glEnvT => unit =
-       "window.reprocessing.Draw.ellipse" [@@bs.val];
+      "window.reprocessing.Draw.subImage";
+    [@bs.val]
+    external rectf : (~pos: (float, float), ~width: float, ~height: float, glEnvT) => unit =
+      "window.reprocessing.Draw.rectf";
+    [@bs.val] external rect : (~pos: (int, int), ~width: int, ~height: int, glEnvT) => unit =
+      "window.reprocessing.Draw.rect";
+    [@bs.val] external linef : (~p1: (float, float), ~p2: (float, float), glEnvT) => unit =
+      "window.reprocessing.Draw.linef";
+    [@bs.val] external line : (~p1: (int, int), ~p2: (int, int), glEnvT) => unit =
+      "window.reprocessing.Draw.line";
+    [@bs.val]
+    external ellipsef : (~center: (float, float), ~radx: float, ~rady: float, glEnvT) => unit =
+      "window.reprocessing.Draw.ellipsef";
+    [@bs.val] external ellipse : (~center: (int, int), ~radx: int, ~rady: int, glEnvT) => unit =
+      "window.reprocessing.Draw.ellipse";
+    [@bs.val]
     external quadf :
-      p1::(float, float) =>
-      p2::(float, float) =>
-      p3::(float, float) =>
-      p4::(float, float) =>
-      glEnvT =>
+      (
+        ~p1: (float, float),
+        ~p2: (float, float),
+        ~p3: (float, float),
+        ~p4: (float, float),
+        glEnvT
+      ) =>
       unit =
-       "window.reprocessing.Draw.quadf" [@@bs.val];
+      "window.reprocessing.Draw.quadf";
+    [@bs.val]
     external quad :
-      p1::(int, int) =>
-      p2::(int, int) =>
-      p3::(int, int) =>
-      p4::(int, int) =>
-      glEnvT =>
-      unit =
-       "window.reprocessing.Draw.quad" [@@bs.val];
-    external pixelf : pos::(float, float) => color::colorT => glEnvT => unit =
-       "window.reprocessing.Draw.pixelf" [@@bs.val];
-    external pixel : pos::(int, int) => color::colorT => glEnvT => unit =
-       "window.reprocessing.Draw.pixel" [@@bs.val];
+      (~p1: (int, int), ~p2: (int, int), ~p3: (int, int), ~p4: (int, int), glEnvT) => unit =
+      "window.reprocessing.Draw.quad";
+    [@bs.val] external pixelf : (~pos: (float, float), ~color: colorT, glEnvT) => unit =
+      "window.reprocessing.Draw.pixelf";
+    [@bs.val] external pixel : (~pos: (int, int), ~color: colorT, glEnvT) => unit =
+      "window.reprocessing.Draw.pixel";
+    [@bs.val]
     external trianglef :
-      p1::(float, float) =>
-      p2::(float, float) =>
-      p3::(float, float) =>
-      glEnvT =>
-      unit =
-       "window.reprocessing.Draw.trianglef" [@@bs.val];
-    external triangle :
-      p1::(int, int) => p2::(int, int) => p3::(int, int) => glEnvT => unit =
-       "window.reprocessing.Draw.triangle" [@@bs.val];
+      (~p1: (float, float), ~p2: (float, float), ~p3: (float, float), glEnvT) => unit =
+      "window.reprocessing.Draw.trianglef";
+    [@bs.val]
+    external triangle : (~p1: (int, int), ~p2: (int, int), ~p3: (int, int), glEnvT) => unit =
+      "window.reprocessing.Draw.triangle";
+    [@bs.val]
     external bezier :
-      p1::(float, float) =>
-      p2::(float, float) =>
-      p3::(float, float) =>
-      p4::(float, float) =>
-      glEnvT =>
+      (
+        ~p1: (float, float),
+        ~p2: (float, float),
+        ~p3: (float, float),
+        ~p4: (float, float),
+        glEnvT
+      ) =>
       unit =
-       "window.reprocessing.Draw.bezier" [@@bs.val];
+      "window.reprocessing.Draw.bezier";
+    [@bs.val]
     external arcf :
-      center::(float, float) =>
-      radx::float =>
-      rady::float =>
-      start::float =>
-      stop::float =>
-      isOpen::bool =>
-      isPie::bool =>
-      glEnvT =>
+      (
+        ~center: (float, float),
+        ~radx: float,
+        ~rady: float,
+        ~start: float,
+        ~stop: float,
+        ~isOpen: bool,
+        ~isPie: bool,
+        glEnvT
+      ) =>
       unit =
-       "window.reprocessing.Draw.arcf" [@@bs.val];
+      "window.reprocessing.Draw.arcf";
+    [@bs.val]
     external arc :
-      center::(int, int) =>
-      radx::int =>
-      rady::int =>
-      start::float =>
-      stop::float =>
-      isOpen::bool =>
-      isPie::bool =>
-      glEnvT =>
+      (
+        ~center: (int, int),
+        ~radx: int,
+        ~rady: int,
+        ~start: float,
+        ~stop: float,
+        ~isOpen: bool,
+        ~isPie: bool,
+        glEnvT
+      ) =>
       unit =
-       "window.reprocessing.Draw.arc" [@@bs.val];
-    external loadFont : filename::string => glEnvT => fontT =
-       "window.reprocessing.Draw.loadFont" [@@bs.val];
-    external text :
-      font::fontT => body::string => pos::(int, int) => glEnvT => unit =
-       "window.reprocessing.Draw.text" [@@bs.val];
-    external clear : glEnvT => unit =
-       "window.reprocessing.Draw.clear" [@@bs.val];
+      "window.reprocessing.Draw.arc";
+    [@bs.val] external loadFont : (~filename: string, glEnvT) => fontT =
+      "window.reprocessing.Draw.loadFont";
+    [@bs.val] external text : (~font: fontT, ~body: string, ~pos: (int, int), glEnvT) => unit =
+      "window.reprocessing.Draw.text";
+    [@bs.val] external clear : glEnvT => unit = "window.reprocessing.Draw.clear";
   };
 
-  /** Contains functions having to do with the environment:
+  /*** Contains functions having to do with the environment:
      * ie window properties, user input
    */
   module Env = {
-    external width : glEnvT => int =
-       "window.reprocessing.Env.width" [@@bs.val];
-    external height : glEnvT => int =
-       "window.reprocessing.Env.height" [@@bs.val];
-    external mouse : glEnvT => (int, int) =
-       "window.reprocessing.Env.mouse" [@@bs.val];
-    external pmouse : glEnvT => (int, int) =
-       "window.reprocessing.Env.pmouse" [@@bs.val];
-    external mousePressed : glEnvT => bool =
-       "window.reprocessing.Env.mousePressed" [@@bs.val];
-    external keyCode : glEnvT => Events.keycodeT =
-       "window.reprocessing.Env.keyCode" [@@bs.val];
-    external size : width::int => height::int => glEnvT => unit =
-       "window.reprocessing.Env.size" [@@bs.val];
-    external resizeable : bool => glEnvT => unit =
-       "window.reprocessing.Env.resizeable" [@@bs.val];
-    external frameRate : glEnvT => int =
-       "window.reprocessing.Env.frameRate" [@@bs.val];
-    external frameCount : glEnvT => int =
-       "window.reprocessing.Env.frameCount" [@@bs.val];
+    [@bs.val] external width : glEnvT => int = "window.reprocessing.Env.width";
+    [@bs.val] external height : glEnvT => int = "window.reprocessing.Env.height";
+    [@bs.val] external mouse : glEnvT => (int, int) = "window.reprocessing.Env.mouse";
+    [@bs.val] external pmouse : glEnvT => (int, int) = "window.reprocessing.Env.pmouse";
+    [@bs.val] external mousePressed : glEnvT => bool = "window.reprocessing.Env.mousePressed";
+    [@bs.val] external keyCode : glEnvT => Events.keycodeT = "window.reprocessing.Env.keyCode";
+    [@bs.val] external size : (~width: int, ~height: int, glEnvT) => unit =
+      "window.reprocessing.Env.size";
+    [@bs.val] external resizeable : (bool, glEnvT) => unit = "window.reprocessing.Env.resizeable";
+    [@bs.val] external frameRate : glEnvT => int = "window.reprocessing.Env.frameRate";
+    [@bs.val] external frameCount : glEnvT => int = "window.reprocessing.Env.frameCount";
   };
 
-  /** Contains utility functions */
+  /*** Contains utility functions */
   module Utils = {
-    external color : r::int => g::int => b::int => colorT =
-       "window.reprocessing.Utils.color" [@@bs.val];
-    external round : float => float =
-       "window.reprocessing.Utils.round" [@@bs.val];
-    external sq : int => int =
-       "window.reprocessing.Utils.sq" [@@bs.val];
-    external pow : base::int => exp::int => int =
-       "window.reprocessing.Utils.pow" [@@bs.val];
-    external constrain : amt::'a => low::'a => high::'a => 'a =
-       "window.reprocessing.Utils.constrain" [@@bs.val];
+    [@bs.val] external color : (~r: int, ~g: int, ~b: int) => colorT =
+      "window.reprocessing.Utils.color";
+    [@bs.val] external round : float => float = "window.reprocessing.Utils.round";
+    [@bs.val] external sq : int => int = "window.reprocessing.Utils.sq";
+    [@bs.val] external pow : (~base: int, ~exp: int) => int = "window.reprocessing.Utils.pow";
+    [@bs.val] external constrain : (~amt: 'a, ~low: 'a, ~high: 'a) => 'a =
+      "window.reprocessing.Utils.constrain";
+    [@bs.val]
     external remapf :
-      value::float =>
-      low1::float =>
-      high1::float =>
-      low2::float =>
-      high2::float =>
-      float =
-       "window.reprocessing.Utils.remapf" [@@bs.val];
-    external remap :
-      value::int => low1::int => high1::int => low2::int => high2::int => int =
-       "window.reprocessing.Utils.remap" [@@bs.val];
-    external norm : value::float => low::float => high::float => float =
-       "window.reprocessing.Utils.norm" [@@bs.val];
-    external randomf : min::float => max::float => float =
-       "window.reprocessing.Utils.randomf" [@@bs.val];
-    external random : min::int => max::int => int =
-       "window.reprocessing.Utils.random" [@@bs.val];
-    external randomSeed : int => unit =
-       "window.reprocessing.Utils.randomSeed" [@@bs.val];
-    external randomGaussian : unit => float =
-       "window.reprocessing.Utils.randomGaussian" [@@bs.val];
-    external lerpf : low::float => high::float => value::float => float =
-       "window.reprocessing.Utils.lerpf" [@@bs.val];
-    external lerp : low::int => high::int => value::float => int =
-       "window.reprocessing.Utils.lerp" [@@bs.val];
-    external lerpColor : low::colorT => high::colorT => value::float => colorT =
-       "window.reprocessing.Utils.lerpColor" [@@bs.val];
-    external distf : p1::(float, float) => p2::(float, float) => float =
-       "window.reprocessing.Utils.distf" [@@bs.val];
-    external dist : p1::(int, int) => p2::(int, int) => float =
-       "window.reprocessing.Utils.dist" [@@bs.val];
-    external magf : (float, float) => float =
-       "window.reprocessing.Utils.magf" [@@bs.val];
-    external mag : (int, int) => float =
-       "window.reprocessing.Utils.mag" [@@bs.val];
-    external degrees : float => float =
-       "window.reprocessing.Utils.degrees" [@@bs.val];
-    external radians : float => float =
-       "window.reprocessing.Utils.radians" [@@bs.val];
-    external noise : float => float => float => float =
-       "window.reprocessing.Utils.noise" [@@bs.val];
-    external noiseSeed : int => unit =
-       "window.reprocessing.Utils.noiseSeed" [@@bs.val];
-    external split : string => sep::char => list string =
-       "window.reprocessing.Utils.split" [@@bs.val];
+      (~value: float, ~low1: float, ~high1: float, ~low2: float, ~high2: float) => float =
+      "window.reprocessing.Utils.remapf";
+    [@bs.val]
+    external remap : (~value: int, ~low1: int, ~high1: int, ~low2: int, ~high2: int) => int =
+      "window.reprocessing.Utils.remap";
+    [@bs.val] external norm : (~value: float, ~low: float, ~high: float) => float =
+      "window.reprocessing.Utils.norm";
+    [@bs.val] external randomf : (~min: float, ~max: float) => float =
+      "window.reprocessing.Utils.randomf";
+    [@bs.val] external random : (~min: int, ~max: int) => int = "window.reprocessing.Utils.random";
+    [@bs.val] external randomSeed : int => unit = "window.reprocessing.Utils.randomSeed";
+    [@bs.val] external randomGaussian : unit => float = "window.reprocessing.Utils.randomGaussian";
+    [@bs.val] external lerpf : (~low: float, ~high: float, ~value: float) => float =
+      "window.reprocessing.Utils.lerpf";
+    [@bs.val] external lerp : (~low: int, ~high: int, ~value: float) => int =
+      "window.reprocessing.Utils.lerp";
+    [@bs.val] external lerpColor : (~low: colorT, ~high: colorT, ~value: float) => colorT =
+      "window.reprocessing.Utils.lerpColor";
+    [@bs.val] external distf : (~p1: (float, float), ~p2: (float, float)) => float =
+      "window.reprocessing.Utils.distf";
+    [@bs.val] external dist : (~p1: (int, int), ~p2: (int, int)) => float =
+      "window.reprocessing.Utils.dist";
+    [@bs.val] external magf : ((float, float)) => float = "window.reprocessing.Utils.magf";
+    [@bs.val] external mag : ((int, int)) => float = "window.reprocessing.Utils.mag";
+    [@bs.val] external degrees : float => float = "window.reprocessing.Utils.degrees";
+    [@bs.val] external radians : float => float = "window.reprocessing.Utils.radians";
+    [@bs.val] external noise : (float, float, float) => float = "window.reprocessing.Utils.noise";
+    [@bs.val] external noiseSeed : int => unit = "window.reprocessing.Utils.noiseSeed";
+    [@bs.val] external split : (string, ~sep: char) => list(string) =
+      "window.reprocessing.Utils.split";
   };
 
-  /** Contains useful constants */
+  /*** Contains useful constants */
   module Constants = {
-    external white : colorT =
-       "window.reprocessing.Constants.white" [@@bs.val];
-    external black : colorT =
-       "window.reprocessing.Constants.black" [@@bs.val];
-    external red : colorT =
-       "window.reprocessing.Constants.red" [@@bs.val];
-    external green : colorT =
-       "window.reprocessing.Constants.green" [@@bs.val];
-    external blue : colorT =
-       "window.reprocessing.Constants.blue" [@@bs.val];
-    external pi : float =
-       "window.reprocessing.Constants.pi" [@@bs.val];
-    external half_pi : float =
-       "window.reprocessing.Constants.half_pi" [@@bs.val];
-    external quarter_pi : float =
-       "window.reprocessing.Constants.quarter_pi" [@@bs.val];
-    external two_pi : float =
-       "window.reprocessing.Constants.two_pi" [@@bs.val];
-    external tau : float =
-       "window.reprocessing.Constants.tau" [@@bs.val];
+    [@bs.val] external white : colorT = "window.reprocessing.Constants.white";
+    [@bs.val] external black : colorT = "window.reprocessing.Constants.black";
+    [@bs.val] external red : colorT = "window.reprocessing.Constants.red";
+    [@bs.val] external green : colorT = "window.reprocessing.Constants.green";
+    [@bs.val] external blue : colorT = "window.reprocessing.Constants.blue";
+    [@bs.val] external pi : float = "window.reprocessing.Constants.pi";
+    [@bs.val] external half_pi : float = "window.reprocessing.Constants.half_pi";
+    [@bs.val] external quarter_pi : float = "window.reprocessing.Constants.quarter_pi";
+    [@bs.val] external two_pi : float = "window.reprocessing.Constants.two_pi";
+    [@bs.val] external tau : float = "window.reprocessing.Constants.tau";
   };
 
-  /** Entrypoint to the graphics library. The system
+  /*** Entrypoint to the graphics library. The system
      * is designed for you to return a self-defined 'state'
      * object from setup, which will then be passed to every
      * callback you choose to implement. Updating the state
      * is done by returning a different value from the callback.
    */
+  [@bs.val]
   external _run :
-    setup::(glEnvT => 'a) =>
-    draw::option ('a => glEnvT => 'a) =>
-    mouseMove::option ('a => glEnvT => 'a) =>
-    mouseDragged::option ('a => glEnvT => 'a) =>
-    mouseDown::option ('a => glEnvT => 'a) =>
-    mouseUp::option ('a => glEnvT => 'a) =>
-    keyPressed::option ('a => glEnvT => 'a) =>
-    keyReleased::option ('a => glEnvT => 'a) =>
-    keyTyped::option ('a => glEnvT => 'a) =>
-    unit =>
+    (
+      ~setup: glEnvT => 'a,
+      ~draw: option((('a, glEnvT) => 'a)),
+      ~mouseMove: option((('a, glEnvT) => 'a)),
+      ~mouseDragged: option((('a, glEnvT) => 'a)),
+      ~mouseDown: option((('a, glEnvT) => 'a)),
+      ~mouseUp: option((('a, glEnvT) => 'a)),
+      ~keyPressed: option((('a, glEnvT) => 'a)),
+      ~keyReleased: option((('a, glEnvT) => 'a)),
+      ~keyTyped: option((('a, glEnvT) => 'a)),
+      unit
+    ) =>
     unit =
-    "window.reprocessing.run" [@@bs.val];
-  let run
-      ::setup
-      ::draw=?
-      ::mouseMove=?
-      ::mouseDragged=?
-      ::mouseDown=?
-      ::mouseUp=?
-      ::keyPressed=?
-      ::keyReleased=?
-      ::keyTyped=?
-      () =>
-    _run
-      ::setup
-      ::draw
-      ::mouseMove
-      ::mouseDragged
-      ::mouseDown
-      ::mouseUp
-      ::keyPressed
-      ::keyReleased
-      ::keyTyped
-      ();
+    "window.reprocessing.run";
+  let run =
+      (
+        ~setup,
+        ~draw=?,
+        ~mouseMove=?,
+        ~mouseDragged=?,
+        ~mouseDown=?,
+        ~mouseUp=?,
+        ~keyPressed=?,
+        ~keyReleased=?,
+        ~keyTyped=?,
+        ()
+      ) =>
+    _run(
+      ~setup,
+      ~draw,
+      ~mouseMove,
+      ~mouseDragged,
+      ~mouseDown,
+      ~mouseUp,
+      ~keyPressed,
+      ~keyReleased,
+      ~keyTyped,
+      ()
+    );
 };


### PR DESCRIPTION
This is just from running the [reason 3 upgrade script](https://github.com/reasonml/upgradeSyntaxFrom2To3) on this repo.

It went mostly smoothly, but there was 1 hiccup that will need to be addressed. The `~val` named arg on [this line](https://github.com/ryanartecona/reprocessing/blob/reason-3/src/Reprocessing_Internal.re#L276) throws a new error under refmt3:

```
Error: 818: val is a reserved keyword, it cannot be used as an identifier. Try `val_' instead
```

I did try just changing it to `val_`, just in case, but it doesn't work.

This will need to be addressed upstream in reasongl-{interface,web,native} whenever those move to reason 3 (though I'm not quite sure why it worked in the first place).