### PR TITLE
Enable localizing mouse canvas coords to current transform context

### DIFF
--- a/src/Reprocessing_Env.re
+++ b/src/Reprocessing_Env.re
@@ -1,5 +1,7 @@
 open Reprocessing_Common;
 
+module Matrix = Reprocessing_Matrix;
+
 let width = (env) => env.size.width;
 
 let height = (env) => env.size.height;
@@ -14,9 +16,11 @@ let keyCode = (env) => env.keyboard.keyCode;
 
 let key = (key, env) => Reprocessing_Common.KeySet.mem(key, env.keyboard.down);
 
-let keyPressed = (key, env) => Reprocessing_Common.KeySet.mem(key, env.keyboard.pressed);
+let keyPressed = (key, env) =>
+  Reprocessing_Common.KeySet.mem(key, env.keyboard.pressed);
 
-let keyReleased = (key, env) => Reprocessing_Common.KeySet.mem(key, env.keyboard.released);
+let keyReleased = (key, env) =>
+  Reprocessing_Common.KeySet.mem(key, env.keyboard.released);
 
 let size = (~width, ~height, env: glEnv) => {
   Reasongl.Gl.Window.setWindowSize(~window=env.window, ~width, ~height);
@@ -30,3 +34,12 @@ let frameRate = (env: glEnv) => env.frame.rate;
 let frameCount = (env: glEnv) => env.frame.count;
 
 let deltaTime = (env: glEnv) => env.frame.deltaTime;
+
+let localizePointf = (p: (float, float), env: glEnv) =>
+  Matrix.(matptmul(matinv(env.matrix), p));
+
+let localizePoint = ((x, y): (int, int), env: glEnv) => {
+  let (lx, ly) =
+    Matrix.(matptmul(matinv(env.matrix), (float_of_int(x), float_of_int(y))));
+  (int_of_float(lx), int_of_float(ly))
+};

--- a/src/Reprocessing_Env.rei
+++ b/src/Reprocessing_Env.rei
@@ -12,9 +12,11 @@ let keyCode: Reprocessing_Types.Types.glEnvT => Reprocessing_Events.keycodeT;
 
 let key: (Reprocessing_Common.KeySet.elt, Reprocessing_Common.glEnv) => bool;
 
-let keyPressed: (Reprocessing_Common.KeySet.elt, Reprocessing_Common.glEnv) => bool;
+let keyPressed:
+  (Reprocessing_Common.KeySet.elt, Reprocessing_Common.glEnv) => bool;
 
-let keyReleased: (Reprocessing_Common.KeySet.elt, Reprocessing_Common.glEnv) => bool;
+let keyReleased:
+  (Reprocessing_Common.KeySet.elt, Reprocessing_Common.glEnv) => bool;
 
 let size: (~width: int, ~height: int, Reprocessing_Types.Types.glEnvT) => unit;
 
@@ -27,3 +29,13 @@ let frameCount: Reprocessing_Types.Types.glEnvT => int;
 
 /*** Time in seconds since the last frame */
 let deltaTime: Reprocessing_Types.Types.glEnvT => float;
+
+
+/***
+ Localize a point in canvas coordinates to the current env's
+ transformed coordinates
+ */
+let localizePoint: ((int, int), Reprocessing_Types.Types.glEnvT) => (int, int);
+
+let localizePointf:
+  ((float, float), Reprocessing_Types.Types.glEnvT) => (float, float);

--- a/src/Reprocessing_Matrix.re
+++ b/src/Reprocessing_Matrix.re
@@ -40,7 +40,10 @@ let copyInto = (~src, ~dst) => {
  */
 let matmatmul = (mat1: array(float), mat2: array(float)) =>
   switch (mat1, mat2) {
-  | ([|m0, m1, m2, m3, m4, m5, m6, m7, m8|], [|ma, mb, mc, md, me, mf, mg, mh, mi|]) =>
+  | (
+      [|m0, m1, m2, m3, m4, m5, m6, m7, m8|],
+      [|ma, mb, mc, md, me, mf, mg, mh, mi|]
+    ) =>
     mat1[0] = ma *. m0 +. md *. m1 +. mg *. m2;
     mat1[1] = mb *. m0 +. me *. m1 +. mh *. m2;
     mat1[2] = mc *. m0 +. mf *. m1 +. mi *. m2;
@@ -74,4 +77,61 @@ let matvecmul = (m, v) => {
  [3 4 5] * [y] = [x3 + y4 + 5]
  [6 7 8]   [1]   [ who cares ]
  */
-let matptmul = (m, (x, y)) => (x *. m[0] +. y *. m[1] +. m[2], x *. m[3] +. y *. m[4] +. m[5]);
+let matptmul = (m, (x, y)) => (
+  x *. m[0] +. y *. m[1] +. m[2],
+  x *. m[3] +. y *. m[4] +. m[5]
+);
+
+
+/***
+ Invert a matrix
+ https://www.geometrictools.com/Documentation/LaplaceExpansionTheorem.pdf
+ */
+let matinv = (mat) =>
+  switch mat {
+  | [|m00, m01, m02, m10, m11, m12, m20, m21, m22|] =>
+    let det =
+      m00
+      *. m11
+      *. m22
+      +. m01
+      *. m12
+      *. m20
+      +. m02
+      *. m10
+      *. m21
+      -. m00
+      *. m12
+      *. m21
+      -. m01
+      *. m10
+      *. m22
+      -. m02
+      *. m11
+      *. m20;
+    if (det == 0.) {
+      invalid_arg("The current transform matrix cannot be inverted")
+    };
+    let invdet = 1. /. det;
+    let adj00 = m11 *. m22 -. m12 *. m21;
+    let adj01 = -. (m01 *. m22 -. m02 *. m21);
+    let adj02 = m01 *. m12 -. m02 *. m11;
+    let adj10 = -. (m10 *. m22 -. m12 *. m20);
+    let adj11 = m00 *. m22 -. m02 *. m20;
+    let adj12 = -. (m00 *. m12 -. m02 *. m10);
+    let adj20 = m10 *. m21 -. m11 *. m20;
+    let adj21 = -. (m00 *. m21 -. m01 *. m20);
+    let adj22 = m00 *. m11 -. m01 *. m10;
+    [|
+      invdet *. adj00,
+      invdet *. adj01,
+      invdet *. adj02,
+      invdet *. adj10,
+      invdet *. adj11,
+      invdet *. adj12,
+      invdet *. adj20,
+      invdet *. adj21,
+      invdet *. adj22
+    |]
+  | _ => assert false
+  };


### PR DESCRIPTION
The big idea here is to make it easier to determine when the mouse interacts with certain visual elements in a scene.

The `Env.mouse(env)` function can tell you the _canvas_ coordinates of the mouse position, but that's not always enough. If I draw a centered square in the middle of a canvas, it's relatively straightforward to determine if the mouse's canvas coordinates are inside or outside that square. But if I have a more complicated scene with multiple levels of transform contexts in the stack, canvas coordinates become less meaningful by themselves. In that scenario, it would be great to be able to get _transformed_ mouse coordinates.

This introduces `Env.localizePoint(point, env)` (and `localizePointf`) to turn canvas coordinates into transform context coordinates, and a `Matrix.matinv(matrix)` to invert an invertible matrix which is needed by `localizePoint`. The current form enables usage like `Env.localizePoint(Env.mouse(env), env)`.

Best I could tell after some searching, other Processing implementations lack this ability. Naming and API are definitely up for discussion, since I was more focused on just making it at least possible without changing the current API which is fairly Processing-faithful.