### PR TITLE
Fix font parsing to accomodate fonts created by gdx-fontpack

### DIFF
--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -142,6 +142,19 @@ module Stream = {
     } else {
       None
     };
+  let skipWhite = ((str, i): t): t => {
+    let len = String.length(str);
+    let rec loop = n => {
+      if (i + n >= len) {
+        (str, i + n)
+      } else if (str.[i + n] === ' ') {
+        loop(n + 1)
+      } else {
+        (str, i + n)
+      }
+    };
+    loop(0);
+  };
   let popn = ((str, i), len) => (str, i + len);
   let switch_ = (stream, matchstr) => {
     let len = String.length(matchstr);

--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -145,18 +145,18 @@ module Stream = {
   let skipWhite = ((str, i): t): t => {
     let len = String.length(str);
     let rec loop = n => {
-      if (i + n >= len) {
-        (str, i + n)
-      } else if (str.[i + n] === ' ') {
+      if (n >= len) {
+        (str, n)
+      } else if (str.[n] === ' ') {
         loop(n + 1)
       } else {
-        (str, i + n)
+        (str, n)
       }
     };
-    loop(0);
+    loop(i);
   };
   let popn = ((str, i), len) => (str, i + len);
-  let switch_ = (stream, matchstr) => {
+  let match = (stream, matchstr) => {
     let len = String.length(matchstr);
     switch (peekn(stream, len)) {
     | Some(peek) when peek == matchstr => popn(stream, len)

--- a/src/Reprocessing_Font.re
+++ b/src/Reprocessing_Font.re
@@ -68,21 +68,21 @@ module Font = {
     if (num <= 0) {
       (stream, map)
     } else {
-      let stream = Stream.switch_(stream, "char id=");
+      let stream = Stream.match(stream, "char id=");
       let (stream, char_id) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "x=");
+      let stream = Stream.match(Stream.skipWhite(stream), "x=");
       let (stream, x) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "y=");
+      let stream = Stream.match(Stream.skipWhite(stream), "y=");
       let (stream, y) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "width=");
+      let stream = Stream.match(Stream.skipWhite(stream), "width=");
       let (stream, width) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "height=");
+      let stream = Stream.match(Stream.skipWhite(stream), "height=");
       let (stream, height) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "xoffset=");
+      let stream = Stream.match(Stream.skipWhite(stream), "xoffset=");
       let (stream, xoffset) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "yoffset=");
+      let stream = Stream.match(Stream.skipWhite(stream), "yoffset=");
       let (stream, yoffset) = parse_num(stream);
-      let stream = Stream.switch_(Stream.skipWhite(stream), "xadvance=");
+      let stream = Stream.match(Stream.skipWhite(stream), "xadvance=");
       let (stream, xadvance) = parse_num(stream);
       let stream = pop_line(stream);
       let new_map = IntMap.add(char_id, {x, y, width, height, xoffset, yoffset, xadvance}, map);
@@ -92,11 +92,11 @@ module Font = {
     if (num == 0) {
       (stream, map)
     } else {
-      let stream = Stream.switch_(stream, "kerning first=");
+      let stream = Stream.match(stream, "kerning first=");
       let (stream, first) = parse_num(stream);
-      let stream = Stream.switch_(stream, " second=");
+      let stream = Stream.match(stream, " second=");
       let (stream, second) = parse_num(stream);
-      let stream = Stream.switch_(stream, " amount=");
+      let stream = Stream.match(stream, " amount=");
       let (stream, amount) = parse_num(stream);
       let stream = pop_line(stream);
       let new_map = IntPairMap.add((first, second), amount, map);
@@ -121,14 +121,14 @@ module Font = {
         (str) => {
           let stream = Stream.create(str ++ "\n");
           let stream = stream |> pop_line |> pop_line;
-          let stream = Stream.switch_(stream, "page id=0 file=\"");
+          let stream = Stream.match(stream, "page id=0 file=\"");
           let (stream, filename) = parse_string(stream);
           let stream = pop_line(stream);
-          let stream = Stream.switch_(stream, "chars count=");
+          let stream = Stream.match(stream, "chars count=");
           let (stream, num_chars) = parse_num(stream);
           let stream = pop_line(stream);
           let (stream, char_map) = parse_char_fmt(stream, num_chars, IntMap.empty);
-          let stream = Stream.switch_(stream, "kernings count=");
+          let stream = Stream.match(stream, "kernings count=");
           let (stream, num_kerns) = parse_num(stream);
           let stream = pop_line(stream);
           let (_, kern_map) = parse_kern_fmt(stream, num_kerns, IntPairMap.empty);

--- a/src/Reprocessing_Font.re
+++ b/src/Reprocessing_Font.re
@@ -65,24 +65,24 @@ module Font = {
     | None => failwith("could not pop line")
     };
   let rec parse_char_fmt = (stream, num, map) =>
-    if (num < 0) {
+    if (num <= 0) {
       (stream, map)
     } else {
       let stream = Stream.switch_(stream, "char id=");
       let (stream, char_id) = parse_num(stream);
-      let stream = Stream.switch_(stream, " x=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "x=");
       let (stream, x) = parse_num(stream);
-      let stream = Stream.switch_(stream, " y=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "y=");
       let (stream, y) = parse_num(stream);
-      let stream = Stream.switch_(stream, " width=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "width=");
       let (stream, width) = parse_num(stream);
-      let stream = Stream.switch_(stream, " height=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "height=");
       let (stream, height) = parse_num(stream);
-      let stream = Stream.switch_(stream, " xoffset=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "xoffset=");
       let (stream, xoffset) = parse_num(stream);
-      let stream = Stream.switch_(stream, " yoffset=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "yoffset=");
       let (stream, yoffset) = parse_num(stream);
-      let stream = Stream.switch_(stream, " xadvance=");
+      let stream = Stream.switch_(Stream.skipWhite(stream), "xadvance=");
       let (stream, xadvance) = parse_num(stream);
       let stream = pop_line(stream);
       let new_map = IntMap.add(char_id, {x, y, width, height, xoffset, yoffset, xadvance}, map);


### PR DESCRIPTION
I was using https://github.com/mattdesl/gdx-fontpack to pack some fonts,
and the font parser died. This makes it more flexible.

Als whatever you're using to pack fonts here
https://github.com/bsansouci/reprocessing-example/blob/livestream-flappybird/assets/flappy.fnt
is getting the `chars count` wrong -- there are 10 chars listed... 🤔