### PR TITLE
improve package.json metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,16 @@
     "type": "git",
     "url": "git+https://github.com/schmavery/reprocessing.git"
   },
+  "homepage": "https://github.com/Schmavery/reprocessing#readme",
+  "bugs": "https://github.com/Schmavery/reprocessing/issues",
+  "keywords": [
+    "reason",
+    "processing",
+    "graphics",
+    "opengl",
+    "webgl"
+  ],
+  "license": "MIT",
   "author": "bsansouci & schmavery",
   "devDependencies": {
     "bs-platform": "bsansouci/bsb-native"


### PR DESCRIPTION
Thanks for adding a license, so I can now also do this (if you're wondering why, see https://redex.github.io/)

You may also want to use the web environment as the homepage instead, perhaps. I just did the standard thing and pointed it to the readme.