### PR TITLE
Lower-case "name" in bsconfig

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "Reprocessing",
+  "name": "reprocessing",
   "sources": [{
     "dir": "src",
     "subdirs": [{


### PR DESCRIPTION
Fixes generating imports that look in the directory node_modules/Reprocessing
with a capital R, which does not exist.