### PR TITLE
Revert changing the package name to lower-case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reprocessing",
+  "name": "Reprocessing",
   "version": "0.1.0",
   "description": "Processing library for Reason",
   "scripts": {

--- a/src/bytecode/Reprocessing_Hotreload_Bytecode.re
+++ b/src/bytecode/Reprocessing_Hotreload_Bytecode.re
@@ -37,7 +37,7 @@ let checkRebuild = (filePath) => {
     /* @Incomplete Check the error code sent back. Also don't do this, use stdout/stderr. */
     let cmd =
       Printf.sprintf(
-        "%s %s -w -40 -I lib/bs/%s/src -I node_modules/bs-platform/vendor/ocaml/lib/ocaml -I node_modules/ReasonglInterface/lib/bs/%s/src -I node_modules/reprocessing/lib/bs/%s/src -pp \"%s --print binary\" -o lib/bs/%s/%s.%s -impl %s 2>&1",
+        "%s %s -w -40 -I lib/bs/%s/src -I node_modules/bs-platform/vendor/ocaml/lib/ocaml -I node_modules/ReasonglInterface/lib/bs/%s/src -I node_modules/Reprocessing/lib/bs/%s/src -pp \"%s --print binary\" -o lib/bs/%s/%s.%s -impl %s 2>&1",
         ocamlPath,
         shared,
         /* folder */


### PR DESCRIPTION
This reverts some commits using the wrong case for the package name.

The package name must match the case in bsconfig.json. This was
causing issues on Linux where filesystems are case sensitive.