### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
     packages:
       - libsdl2-dev
       - fcitx-libs-dev
-      - libdbus-1-dev
       - libibus-1.0-dev
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ cache:
   directories:
     - node_modules
 before_script:
-  - sudo apt-get update
-  - sudo apt-get install \
-      dbus \
-      ibus
+  - sudo apt-get update && \
+    sudo apt-get install -qq \
+      libdbus-1-dev \
+      libibus-1.0-dev
 script:
   - npm install
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ node_js:
 cache:
   directories:
     - node_modules
+before_script:
+  - sudo apt-get update
+  - sudo apt-get install \
+      dbus \
+      ibus
 script:
   - npm install
   - npm run build
   - npm run build:bytecode
   - npm run build:native
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: trusty
 language: node_js
 node_js:
   - 8
+sudo: required
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,14 @@ dist: trusty
 language: node_js
 node_js:
   - 8
-sudo: required
+addons:
+  apt:
+    packages:
+      - libdbus-1-dev
+      - libibus-1.0-dev
 cache:
   directories:
     - node_modules
-before_script:
-  - sudo apt-get update && \
-    sudo apt-get install -qq \
-      libdbus-1-dev \
-      libibus-1.0-dev
 script:
   - npm install
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 addons:
   apt:
     packages:
+      - fcitx-libs
       - libdbus-1-dev
       - libibus-1.0-dev
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: trusty
+language: node_js
+node_js:
+  - 8
+cache:
+  directories:
+    - node_modules
+script:
+  - npm install
+  - npm run build
+  - npm run build:bytecode
+  - npm run build:native
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
 addons:
   apt:
     packages:
+      - libsdl2-dev
       - fcitx-libs-dev
       - libdbus-1-dev
       - libibus-1.0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 addons:
   apt:
     packages:
-      - fcitx-libs
+      - fcitx-libs-dev
       - libdbus-1-dev
       - libibus-1.0-dev
 cache:


### PR DESCRIPTION
This runs native, bytecode and web builds on an Ubuntu Trusty container. It should let us know if we unwittingly break the build on Linux.

![screenshot from 2018-04-07 14-29-24](https://user-images.githubusercontent.com/542191/38460531-8d423188-3a70-11e8-9fe5-768ad712336b.png)

Fixes #77.