### PR TITLE
Temporary fix for spritesheet artifact issue

### DIFF
--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -919,11 +919,12 @@ let drawImage =
     | None => {r: 1., g: 1., b: 1., a: 1.}
     };
   maybeFlushBatch(~texture=Some(texture), ~vert=32, ~el=6, env);
+  /* TODO: fix very hacky MSAA artifact issue properly.. lines on edges of spritesheet */
   let (fsubx, fsuby, fsubw, fsubh) = (
-    float_of_int(subx) /. float_of_int(imgw),
-    float_of_int(suby) /. float_of_int(imgh),
-    float_of_int(subw) /. float_of_int(imgw),
-    float_of_int(subh) /. float_of_int(imgh)
+    float_of_int(subx) /. float_of_int(imgw) +. 0.0004,
+    float_of_int(suby) /. float_of_int(imgh) +. 0.0004,
+    float_of_int(subw) /. float_of_int(imgw) -. 0.0008,
+    float_of_int(subh) /. float_of_int(imgh) -. 0.0008
   );
   let set = Gl.Bigarray.set;
   let ii = env.batch.vertexPtr;


### PR DESCRIPTION
There's probably a better way to do this but it seems like this goes a long way towards fixing the issues we've been seeing with textures bleeding.
This is currently thought to be caused by MSAA picking up nearby pixels. Values were experimentally determined.

This (https://gamedev.stackexchange.com/questions/134948/opengl-texture-bleeding) suggests to: 
> Ensure that when the fragment shader actually samples the textures it never samples less than 1/2 a pixel from any border.

Which sounds awesome except I have no idea how to do that.