### PR TITLE
Fix #91 jpg loading issue

### DIFF
--- a/src/Reprocessing_Internal.re
+++ b/src/Reprocessing_Internal.re
@@ -796,6 +796,7 @@ let loadImage = (env: glEnv, filename, isPixel) : imageT => {
   let imageRef = {glData: None, drawnTo: false};
   Gl.loadImage(
     ~filename,
+    ~loadOption=LoadRGBA,
     ~callback=
       imageData =>
         switch imageData {
@@ -848,6 +849,7 @@ let loadImageFromMemory = (env: glEnv, data, isPixel) : imageT => {
   let imageRef = {glData: None, drawnTo: false};
   Gl.loadImageFromMemory(
     ~data,
+    ~loadOption=LoadRGBA,
     ~callback=
       imageData =>
         switch imageData {


### PR DESCRIPTION
This looks like it fixes the issue with loading jpgs. I believe this will tell reasongl (which tells SOIL) to load in the data as RGBA no matter what the source image format is. This is probably the best option for us right now as iirc reprocessing isn't set up to handle different image formats currently. We could make it do that but it would be a bigger fix so let's see if we even end up needing it.

cc @bsansouci @codekiln