### PR TITLE
Pin to version of reasongl

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -15,7 +15,7 @@
     "dir": "examples",
     "type": "dev"
   }],
-  "bs-dependencies": ["Reasongl"],
+  "bs-dependencies": ["reasongl"],
   "entries": [{
     "backend": "bytecode",
     "main-module": "IndexHot"

--- a/bsconfig.json
+++ b/bsconfig.json
@@ -15,7 +15,7 @@
     "dir": "examples",
     "type": "dev"
   }],
-  "bs-dependencies": ["reasongl"],
+  "bs-dependencies": ["@bsansouci/reasongl"],
   "entries": [{
     "backend": "bytecode",
     "main-module": "IndexHot"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "@bsansouci/reasongl": "^0.2.4",
-    "dynlink": "bsansouci/otherlibs"
+    "@bsansouci/reasongl": "^0.2.4"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "Reasongl": "github:bsansouci/reasongl#868ca060c7fe41595fe6157c7ab668af82a170e1"
+    "reasongl": "^0.2.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "reasongl": "^0.2.0"
+    "reasongl": "^0.2.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "reasongl": "^0.2.1"
+    "@bsansouci/reasongl": "^0.2.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reprocessing",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Processing library for Reason",
   "scripts": {
     "build": "bsb -make-world -backend js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "clean": "bsb -clean-world"
   },
   "dependencies": {
-    "@bsansouci/reasongl": "^0.2.2"
+    "@bsansouci/reasongl": "^0.2.4",
+    "dynlink": "bsansouci/otherlibs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I made reasongl point to versions of tgls and tsdl https://github.com/bsansouci/reasongl/blob/7471820a399c4f3ef538bf83a5c2fe765a865820/package.json

Both have their sub-1.0 version and their 1.0 version