### PR TITLE
Rescript 10 Support

### DIFF
--- a/src/Reprocessing_Common.re
+++ b/src/Reprocessing_Common.re
@@ -181,23 +181,6 @@ module Stream = {
   let create = (str: string) : t => (str, 0);
 };
 
-let read = (name: string) => {
-  let ic = open_in(name);
-  let try_read = () =>
-    switch (input_line(ic)) {
-    | exception End_of_file => None
-    | x => Some(x)
-    };
-  let rec loop = (acc) =>
-    switch (try_read()) {
-    | Some(s) => loop([String.make(1, '\n'), s, ...acc])
-    | None =>
-      close_in(ic);
-      List.rev(acc)
-    };
-  loop([]) |> String.concat("")
-};
-
 let append_char = (s: string, c: char) : string => s ++ String.make(1, c);
 
 let rec split = (stream, sep, accstr, acc) =>

--- a/src/Reprocessing_Font.re
+++ b/src/Reprocessing_Font.re
@@ -84,7 +84,7 @@ module Font = {
     if (num < 0) {
       (stream, map);
     } else if (Stream.peekn(stream, 4) != Some("char")) {
-      prerr_string(
+      print_string(
         "Warning: encountered end of char sequence early when loading font.\n"
       );
       (stream, map);


### PR DESCRIPTION
When trying to get ReTurbo working on ReScript version 10 I found the following had to be removed/tweaked as the underlying functions have been removed.

`open_in` -- only used by `read`, not sure what the alternative here would be. I don't use this and nothing else in the codebase does, maybe it's safe to remove?

`prerr_string` -- which can be at least replaced by `print_string`